### PR TITLE
refactor: ComicService のリファクタリング

### DIFF
--- a/api/Comical.Api/Models/ComicList.cs
+++ b/api/Comical.Api/Models/ComicList.cs
@@ -40,7 +40,7 @@ namespace Comical.Api.Models
             {
                 var image = comicImages.FirstOrDefault(c => c.Isbn == comic.Isbn);
 
-                if (image != null && !string.IsNullOrEmpty(image.ImageStorageUrl))
+                if (!string.IsNullOrEmpty(image?.ImageStorageUrl))
                 {
                     comic.ImageStorageUrl = BaserUrl + image.ImageStorageUrl;
                 }

--- a/api/Comical.Api/Models/ComicList.cs
+++ b/api/Comical.Api/Models/ComicList.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Comical.Api.Models
+{
+    public class ComicList
+    {
+        private const string BaserUrl = "https://stmanrim.blob.core.windows.net/image";
+
+        private readonly IEnumerable<Comic> _comics;
+
+        public ComicList(IEnumerable<Comic> comics)
+        {
+            _comics = comics;
+        }
+
+        public IEnumerable<Comic> GetComics() => _comics;
+
+        public ComicList Search(IEnumerable<string> searchList)
+        {
+            var comics = searchList
+                .SelectMany(keyword => _comics
+                    .Where(w => w.Title.Contains(keyword)
+                                || w.Author.Contains(keyword)))
+                .Distinct()
+                .OrderBy(o => o.SalesDate)
+                .ToList();
+
+            return new ComicList(comics);
+        }
+
+        public IEnumerable<string> GetIsbns()
+        {
+            return _comics.Select(c => c.Isbn).ToList();
+        }
+
+        public ComicList GetComicsWithImage(IEnumerable<ComicImage> comicImages)
+        {
+            foreach (var comic in _comics)
+            {
+                var image = comicImages.FirstOrDefault(c => c.Isbn == comic.Isbn);
+
+                if (image != null && !string.IsNullOrEmpty(image.ImageStorageUrl))
+                {
+                    comic.ImageStorageUrl = BaserUrl + image.ImageStorageUrl;
+                }
+            }
+
+            return new ComicList(_comics);
+        }
+    }
+}


### PR DESCRIPTION
- Comic のファーストコレクションクラス ComicList を実装しました。
- ComicService をリファクタリングしました。
- ComicService の39行目で全コミックの ISBN を取得して、40行目で全コミックのイメージを取得する処理になってました。  
検索ワードで絞り込んだ ISBN だけを対象に、コミックのイメージを取得するように修正しました。