### PR TITLE
chore(ci): add path filtering to CI/CD/PR-preview workflows

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -15,35 +15,96 @@ permissions:
   id-token: write # Required for OIDC
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+      db: ${{ steps.filter.outputs.db }}
+      infra: ${{ steps.filter.outputs.infra }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+      deploy_config: ${{ steps.filter.outputs.deploy_config }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'src/frontend/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.nvmrc'
+              - 'staticwebapp.config.json'
+            backend:
+              - 'src/backend/**'
+              - 'global.json'
+            db:
+              - 'src/db/**'
+            infra:
+              - 'infra/**'
+            workflows:
+              - '.github/workflows/cd-dev.yml'
+            deploy_config:
+              - 'staticwebapp.config.json'
+
   deploy-dev:
     name: Deploy to Dev
+    needs: changes
     runs-on: ubuntu-latest
     environment: dev
     concurrency:
       group: deploy-dev
       cancel-in-progress: false
+    env:
+      RUN_INFRA: ${{ needs.changes.outputs.infra == 'true' || needs.changes.outputs.workflows == 'true' || github.event_name == 'workflow_dispatch' }}
+      RUN_DB: ${{ needs.changes.outputs.db == 'true' || needs.changes.outputs.workflows == 'true' || github.event_name == 'workflow_dispatch' }}
+      RUN_BACKEND: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.workflows == 'true' || github.event_name == 'workflow_dispatch' }}
+      RUN_FRONTEND: ${{ needs.changes.outputs.frontend == 'true' || needs.changes.outputs.workflows == 'true' || github.event_name == 'workflow_dispatch' }}
 
     steps:
+      - name: Show what will run
+        run: |
+          echo "infra=$RUN_INFRA"
+          echo "db=$RUN_DB"
+          echo "backend=$RUN_BACKEND"
+          echo "frontend=$RUN_FRONTEND"
+
+      - name: Skip entire deploy (no relevant changes)
+        if: env.RUN_INFRA != 'true' && env.RUN_DB != 'true' && env.RUN_BACKEND != 'true' && env.RUN_FRONTEND != 'true'
+        run: |
+          echo "::notice::No infra/db/backend/frontend changes detected. Skipping deploy."
+          exit 0
+
       - name: Checkout
+        if: env.RUN_INFRA == 'true' || env.RUN_DB == 'true' || env.RUN_BACKEND == 'true' || env.RUN_FRONTEND == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
+        if: env.RUN_DB == 'true' || env.RUN_BACKEND == 'true'
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           global-json-file: global.json
 
       - name: Setup Node.js
+        if: env.RUN_FRONTEND == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Setup pnpm
+        if: env.RUN_FRONTEND == 'true'
         uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4
         with:
           version: '10'
           run_install: false
 
       - name: Azure Login (OIDC)
+        if: env.RUN_INFRA == 'true' || env.RUN_DB == 'true' || env.RUN_BACKEND == 'true'
         uses: azure/login@eec3c95657c1536435858eda1f3ff5437fee8474 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -51,6 +112,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Bicep What-If
+        if: env.RUN_INFRA == 'true'
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
         run: |
@@ -60,6 +122,7 @@ jobs:
             --parameters infra/params/dev.bicepparam
 
       - name: Bicep Deploy
+        if: env.RUN_INFRA == 'true'
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
         run: |
@@ -71,8 +134,21 @@ jobs:
 
       - name: Get deployment outputs
         id: outputs
+        if: env.RUN_DB == 'true' || env.RUN_BACKEND == 'true'
         run: |
-          DEPLOY_NAME="deploy-dev-${{ github.run_number }}"
+          if [ "$RUN_INFRA" = "true" ]; then
+            DEPLOY_NAME="deploy-dev-${{ github.run_number }}"
+          else
+            # Reuse outputs from the most recent successful Bicep deployment
+            DEPLOY_NAME=$(az deployment sub list \
+              --query "sort_by([?starts_with(name, 'deploy-dev-') && properties.provisioningState=='Succeeded'], &properties.timestamp)[-1].name" \
+              -o tsv)
+            if [ -z "$DEPLOY_NAME" ]; then
+              echo "::error::No prior successful deploy-dev-* deployment found and infra step was skipped."
+              exit 1
+            fi
+            echo "Using prior deployment: $DEPLOY_NAME"
+          fi
           SQL_FQDN=$(az deployment sub show --name "$DEPLOY_NAME" --query "properties.outputs.sqlServerFqdn.value" -o tsv)
           SQL_DB=$(az deployment sub show --name "$DEPLOY_NAME" --query "properties.outputs.sqlDatabaseName.value" -o tsv)
           API_APP=$(az deployment sub show --name "$DEPLOY_NAME" --query "properties.outputs.funcApiName.value" -o tsv)
@@ -85,6 +161,7 @@ jobs:
           echo "rg=$RG" >> $GITHUB_OUTPUT
 
       - name: DB Publish (sqlpackage)
+        if: env.RUN_DB == 'true'
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
         run: |
@@ -100,21 +177,25 @@ jobs:
             /p:BlockOnPossibleDataLoss=true
 
       - name: Build Backend
+        if: env.RUN_BACKEND == 'true'
         run: dotnet build src/backend/ComiCal.slnx --configuration Release
 
       - name: Publish API Functions
+        if: env.RUN_BACKEND == 'true'
         run: |
           dotnet publish src/backend/api/ComiCal.Api/ComiCal.Api.csproj \
             --configuration Release --output ./publish/api
           cd publish/api && zip -r ../../api.zip .
 
       - name: Publish Batch Functions
+        if: env.RUN_BACKEND == 'true'
         run: |
           dotnet publish src/backend/batch/ComiCal.Batch/ComiCal.Batch.csproj \
             --configuration Release --output ./publish/batch
           cd publish/batch && zip -r ../../batch.zip .
 
       - name: Deploy API to Azure Functions
+        if: env.RUN_BACKEND == 'true'
         run: |
           az functionapp deployment source config-zip \
             --resource-group "${{ steps.outputs.outputs.rg }}" \
@@ -122,6 +203,7 @@ jobs:
             --src api.zip
 
       - name: Deploy Batch to Azure Functions
+        if: env.RUN_BACKEND == 'true'
         run: |
           az functionapp deployment source config-zip \
             --resource-group "${{ steps.outputs.outputs.rg }}" \
@@ -129,6 +211,7 @@ jobs:
             --src batch.zip
 
       - name: Build Frontend
+        if: env.RUN_FRONTEND == 'true'
         run: |
           pnpm install
           pnpm --filter frontend build
@@ -136,6 +219,7 @@ jobs:
           cp staticwebapp.config.json src/frontend/dist/frontend/browser/staticwebapp.config.json
 
       - name: Deploy Frontend to SWA
+        if: env.RUN_FRONTEND == 'true'
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.SWA_DEPLOY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,39 @@ permissions:
   pull-requests: write
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+      db: ${{ steps.filter.outputs.db }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'src/frontend/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.nvmrc'
+            backend:
+              - 'src/backend/**'
+              - 'src/tests/backend/**'
+              - 'global.json'
+            db:
+              - 'src/db/**'
+            workflows:
+              - '.github/workflows/**'
+
   lint-frontend:
     name: Lint Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,6 +62,8 @@ jobs:
 
   test-frontend:
     name: Test Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -53,6 +86,8 @@ jobs:
 
   build-frontend:
     name: Build Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -70,6 +105,8 @@ jobs:
 
   lint-backend:
     name: Lint Backend
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -83,6 +120,8 @@ jobs:
 
   test-backend:
     name: Test Backend
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -106,6 +145,8 @@ jobs:
 
   build-db:
     name: Build DB (SSDT)
+    needs: changes
+    if: needs.changes.outputs.db == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -114,3 +155,27 @@ jobs:
           global-json-file: global.json
       - name: Build DACPAC
         run: dotnet build src/db/ComiCal.Database.sqlproj
+
+  ci-passed:
+    name: CI Passed
+    needs:
+      - lint-frontend
+      - test-frontend
+      - build-frontend
+      - lint-backend
+      - test-backend
+      - build-db
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs succeeded or were skipped
+        env:
+          RESULTS: ${{ toJson(needs) }}
+        run: |
+          echo "$RESULTS"
+          # Skipped is acceptable (path-filtered out); failure / cancelled are not.
+          if echo "$RESULTS" | grep -E '"result"[[:space:]]*:[[:space:]]*"(failure|cancelled)"'; then
+            echo "::error::One or more required CI jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required CI jobs succeeded or were skipped (path-filtered)."

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -9,9 +9,33 @@ permissions:
   pull-requests: write
 
 jobs:
-  build-and-deploy:
+  changes:
+    name: Detect changes
     if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'src/frontend/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.nvmrc'
+              - 'staticwebapp.config.json'
+            workflows:
+              - '.github/workflows/pr-preview.yml'
+
+  build-and-deploy:
     name: Build and Deploy Preview
+    needs: changes
+    if: github.event.action != 'closed' && (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.workflows == 'true')
     runs-on: ubuntu-latest
     environment: dev
     steps:


### PR DESCRIPTION
## 概要

`dorny/paths-filter` を導入し、変更ファイルに関係ないジョブ/ステップをスキップします。

## 変更点

### `ci.yml`
- `changes` ジョブで frontend/backend/db/workflows を検出
- 各ジョブに `if: needs.changes.outputs.<area> == 'true' || needs.changes.outputs.workflows == 'true'` を付与
- `ci-passed` アグリゲータジョブを追加（`if: always()` + `toJson(needs)` で skipped は許容、failure/cancelled のみ落とす）

### `cd-dev.yml`
- 同じ `changes` ジョブ + ステップレベル `if:` ガード
- Bicep deploy は `infra/**` 変更時のみ実行。それ以外は最新の成功済み `deploy-dev-*` から outputs を再取得
- DB/Backend/Frontend のビルド・デプロイは該当パス変更時のみ
- `workflow_dispatch` 時は全ステップ強制実行

### `pr-preview.yml`
- frontend 変更がない PR では SWA プレビュービルドをスキップ

### `cd-prod.yml`
- **意図的に変更せず**。prod は tag 駆動かつ低頻度、コンポーネントを一括デプロイしてドリフトリスクを最小化

## ⚠️ 要対応（マージ後）

ブランチ保護ルールの required status checks を、個別ジョブ名ではなく **`ci-passed`** に切り替えてください。これがないと skipped ジョブが "missing" 扱いで PR をブロックします。

## 関連
- 直近の Dependabot 一括マージで CD が毎回フルで回って時間を浪費していた件への対応
- `.github/copilot-instructions.md` のブランチ運用ポリシーは別 PR (#226) で対応済み