### PR TITLE
fix(infra,cd): grant Function App MIs database access

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -130,7 +130,9 @@ jobs:
           az deployment sub what-if \
             --location japaneast \
             --template-file infra/main.bicep \
-            --parameters infra/params/dev.bicepparam
+            --parameters infra/params/dev.bicepparam \
+            --parameters sqlEntraAdminLogin='comical-github-oidc' \
+            --parameters sqlEntraAdminObjectId='${{ vars.AZURE_CLIENT_OBJECT_ID }}'
 
       - name: Bicep Deploy
         if: env.RUN_INFRA == 'true'
@@ -141,11 +143,13 @@ jobs:
             --location japaneast \
             --template-file infra/main.bicep \
             --parameters infra/params/dev.bicepparam \
+            --parameters sqlEntraAdminLogin='comical-github-oidc' \
+            --parameters sqlEntraAdminObjectId='${{ vars.AZURE_CLIENT_OBJECT_ID }}' \
             --name "deploy-dev-${{ github.run_number }}"
 
       - name: Get deployment outputs
         id: outputs
-        if: env.RUN_DB == 'true' || env.RUN_BACKEND == 'true'
+        if: env.RUN_INFRA == 'true' || env.RUN_DB == 'true' || env.RUN_BACKEND == 'true'
         run: |
           if [ "$RUN_INFRA" = "true" ]; then
             DEPLOY_NAME="deploy-dev-${{ github.run_number }}"
@@ -186,6 +190,78 @@ jobs:
             /TargetPassword:"$SQL_ADMIN_PASSWORD" \
             /TargetEncryptConnection:True \
             /p:BlockOnPossibleDataLoss=true
+
+      - name: Grant Function MIs DB access
+        # Idempotently CREATE USER FROM EXTERNAL PROVIDER (via SID) and grant
+        # db_datareader / db_datawriter to the API and Batch Function App MIs.
+        # Runs whenever infra/db/backend changed (any of which may add/rotate the MIs or DB).
+        if: env.RUN_INFRA == 'true' || env.RUN_DB == 'true' || env.RUN_BACKEND == 'true'
+        run: |
+          set -euo pipefail
+          # Install go-sqlcmd (single static binary, supports --access-token-file)
+          curl -sSL -o /tmp/sqlcmd.tar.bz2 \
+            https://github.com/microsoft/go-sqlcmd/releases/download/v1.8.0/sqlcmd-linux-amd64.tar.bz2
+          mkdir -p /tmp/sqlcmd && tar -xjf /tmp/sqlcmd.tar.bz2 -C /tmp/sqlcmd
+          SQLCMD=/tmp/sqlcmd/sqlcmd
+
+          RG='${{ steps.outputs.outputs.rg }}'
+          API_APP='${{ steps.outputs.outputs.apiApp }}'
+          BATCH_APP='${{ steps.outputs.outputs.batchApp }}'
+          SQL_FQDN='${{ steps.outputs.outputs.sqlFqdn }}'
+          SQL_DB='${{ steps.outputs.outputs.sqlDb }}'
+
+          API_PID=$(az functionapp identity show -g "$RG" -n "$API_APP" --query principalId -o tsv)
+          BATCH_PID=$(az functionapp identity show -g "$RG" -n "$BATCH_APP" --query principalId -o tsv)
+
+          cat > /tmp/grant.sql <<SQL
+          SET NOCOUNT ON;
+          DECLARE @apiName  sysname = N'$API_APP';
+          DECLARE @apiPid   uniqueidentifier = N'$API_PID';
+          DECLARE @bchName  sysname = N'$BATCH_APP';
+          DECLARE @bchPid   uniqueidentifier = N'$BATCH_PID';
+
+          IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = @apiName)
+          BEGIN
+              DECLARE @apiSid varbinary(16) = CONVERT(varbinary(16), @apiPid);
+              DECLARE @apiSql nvarchar(max) = N'CREATE USER ' + QUOTENAME(@apiName)
+                  + N' WITH SID = ' + CONVERT(nvarchar(100), @apiSid, 1) + N', TYPE = E';
+              EXEC sp_executesql @apiSql;
+          END;
+
+          IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = @bchName)
+          BEGIN
+              DECLARE @bchSid varbinary(16) = CONVERT(varbinary(16), @bchPid);
+              DECLARE @bchSql nvarchar(max) = N'CREATE USER ' + QUOTENAME(@bchName)
+                  + N' WITH SID = ' + CONVERT(nvarchar(100), @bchSid, 1) + N', TYPE = E';
+              EXEC sp_executesql @bchSql;
+          END;
+
+          DECLARE @addRoleApiR  nvarchar(max) = N'ALTER ROLE db_datareader ADD MEMBER ' + QUOTENAME(@apiName);
+          DECLARE @addRoleApiW  nvarchar(max) = N'ALTER ROLE db_datawriter ADD MEMBER ' + QUOTENAME(@apiName);
+          DECLARE @addRoleBchR  nvarchar(max) = N'ALTER ROLE db_datareader ADD MEMBER ' + QUOTENAME(@bchName);
+          DECLARE @addRoleBchW  nvarchar(max) = N'ALTER ROLE db_datawriter ADD MEMBER ' + QUOTENAME(@bchName);
+
+          IF NOT EXISTS (SELECT 1 FROM sys.database_role_members rm
+              JOIN sys.database_principals r ON rm.role_principal_id = r.principal_id
+              JOIN sys.database_principals m ON rm.member_principal_id = m.principal_id
+              WHERE r.name = N'db_datareader' AND m.name = @apiName) EXEC sp_executesql @addRoleApiR;
+          IF NOT EXISTS (SELECT 1 FROM sys.database_role_members rm
+              JOIN sys.database_principals r ON rm.role_principal_id = r.principal_id
+              JOIN sys.database_principals m ON rm.member_principal_id = m.principal_id
+              WHERE r.name = N'db_datawriter' AND m.name = @apiName) EXEC sp_executesql @addRoleApiW;
+          IF NOT EXISTS (SELECT 1 FROM sys.database_role_members rm
+              JOIN sys.database_principals r ON rm.role_principal_id = r.principal_id
+              JOIN sys.database_principals m ON rm.member_principal_id = m.principal_id
+              WHERE r.name = N'db_datareader' AND m.name = @bchName) EXEC sp_executesql @addRoleBchR;
+          IF NOT EXISTS (SELECT 1 FROM sys.database_role_members rm
+              JOIN sys.database_principals r ON rm.role_principal_id = r.principal_id
+              JOIN sys.database_principals m ON rm.member_principal_id = m.principal_id
+              WHERE r.name = N'db_datawriter' AND m.name = @bchName) EXEC sp_executesql @addRoleBchW;
+          SQL
+
+          az account get-access-token --resource https://database.windows.net --query accessToken -o tsv > /tmp/dbtoken
+          $SQLCMD -S "$SQL_FQDN" -d "$SQL_DB" --access-token-file /tmp/dbtoken -i /tmp/grant.sql -b
+          rm -f /tmp/dbtoken
 
       - name: Build Backend
         if: env.RUN_BACKEND == 'true'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -19,6 +19,12 @@ param sqlAdminLogin string = 'sqladmin'
 @description('SQL Server administrator password — supply via CI/CD secret, not bicepparam')
 param sqlAdminPassword string
 
+@description('Entra ID admin login name on SQL Server (display name of the deploying SP)')
+param sqlEntraAdminLogin string
+
+@description('Entra ID admin object ID on SQL Server (the SP\'s objectId, not the appId)')
+param sqlEntraAdminObjectId string
+
 @description('Log Analytics workspace retention in days (30 for dev, 90 for prod)')
 param logRetentionDays int = 30
 
@@ -61,6 +67,8 @@ module data 'modules/data.bicep' = {
     sqlVCores: sqlVCores
     sqlAdminLogin: sqlAdminLogin
     sqlAdminPassword: sqlAdminPassword
+    sqlEntraAdminLogin: sqlEntraAdminLogin
+    sqlEntraAdminObjectId: sqlEntraAdminObjectId
   }
   dependsOn: [
     observability

--- a/infra/modules/data.bicep
+++ b/infra/modules/data.bicep
@@ -17,6 +17,12 @@ param sqlAdminLogin string = 'sqladmin'
 @description('SQL Server administrator password')
 param sqlAdminPassword string
 
+@description('Entra ID admin login name on SQL Server (display name of the principal — typically the deploying SP)')
+param sqlEntraAdminLogin string
+
+@description('Entra ID admin object ID on SQL Server (NOT the application/client ID)')
+param sqlEntraAdminObjectId string
+
 var sqlServerName = '${prefix}-${env}-jpe-sql'
 var sqlDatabaseName = '${prefix}-${env}-jpe-sqldb'
 // Storage account names must be lowercase alphanumeric, no hyphens, max 24 chars.
@@ -36,6 +42,17 @@ resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
     minimalTlsVersion: '1.2'
     // Allow Azure services to connect (required for Functions → SQL without VNet)
     publicNetworkAccess: 'Enabled'
+    // Entra (AAD) admin — required so the deploying SP can issue
+    // CREATE USER FROM EXTERNAL PROVIDER for Function App managed identities.
+    // SQL admin login is retained (azureADOnlyAuthentication: false) for sqlpackage DACPAC publish.
+    administrators: {
+      administratorType: 'ActiveDirectory'
+      principalType: 'Application'
+      login: sqlEntraAdminLogin
+      sid: sqlEntraAdminObjectId
+      tenantId: subscription().tenantId
+      azureADOnlyAuthentication: false
+    }
   }
 }
 


### PR DESCRIPTION
## 問題

Durable Functions の `DailyBatchTimer` は毎日 18:00 UTC（03:00 JST）に起動しているが、すべて失敗。

App Insights の例外:
```
Microsoft.Data.SqlClient.SqlException
Login failed for user '<token-identified principal>'.
The server is not currently configured to accept this token.
```

### 原因
- Function App は `Authentication=Active Directory Default` で接続しており、システム割り当て MI のトークンで SQL に接続している
- だが MI は **DB ユーザーとして登録されていない**
- かつ SQL Server に **Entra 管理者が未設定**で、誰も `CREATE USER FROM EXTERNAL PROVIDER` を実行できない状態

## 修正内容

### Bicep
- `data.bicep` / `main.bicep` の SQL Server に `administrators` ブロックを追加
  - `comical-github-oidc` SP を Entra 管理者に設定
  - `azureADOnlyAuthentication: false` で SqlPackage の SQL 管理者ログインも併用可能のまま

### CD
- `cd-dev.yml` の Bicep What-If/Deploy に `sqlEntraAdminLogin` / `sqlEntraAdminObjectId` を渡す（objectId は repo variable `AZURE_CLIENT_OBJECT_ID` に保存済み）
- DACPAC publish 後に **"Grant Function MIs DB access"** ステップを追加
  - go-sqlcmd を取得
  - `database.windows.net` のアクセストークンをデプロイ SP で取得
  - **SID 方式の `CREATE USER`** を idempotent に実行（principalId GUID から SID を生成するので Microsoft Graph 権限不要）
  - `db_datareader` / `db_datawriter` を両 MI に付与（既メンバーなら NOOP）

## 動作確認

マージ後、workflow_dispatch で CD-Dev を実行 → 翌日 03:00 JST のバッチが成功することを確認します。

## Closes
バッチ実行失敗（直近 30 日連続）