### PR TITLE
fix(infra,cd): declare Entra admin params in bicepparam files

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -126,25 +126,23 @@ jobs:
         if: env.RUN_INFRA == 'true'
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
+          SQL_ENTRA_ADMIN_OBJECT_ID: ${{ vars.AZURE_CLIENT_OBJECT_ID }}
         run: |
           az deployment sub what-if \
             --location japaneast \
             --template-file infra/main.bicep \
-            --parameters infra/params/dev.bicepparam \
-            --parameters sqlEntraAdminLogin='comical-github-oidc' \
-            --parameters sqlEntraAdminObjectId='${{ vars.AZURE_CLIENT_OBJECT_ID }}'
+            --parameters infra/params/dev.bicepparam
 
       - name: Bicep Deploy
         if: env.RUN_INFRA == 'true'
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
+          SQL_ENTRA_ADMIN_OBJECT_ID: ${{ vars.AZURE_CLIENT_OBJECT_ID }}
         run: |
           az deployment sub create \
             --location japaneast \
             --template-file infra/main.bicep \
             --parameters infra/params/dev.bicepparam \
-            --parameters sqlEntraAdminLogin='comical-github-oidc' \
-            --parameters sqlEntraAdminObjectId='${{ vars.AZURE_CLIENT_OBJECT_ID }}' \
             --name "deploy-dev-${{ github.run_number }}"
 
       - name: Get deployment outputs

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Bicep What-If
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
+          SQL_ENTRA_ADMIN_OBJECT_ID: ${{ vars.AZURE_CLIENT_OBJECT_ID }}
         run: |
           az deployment sub what-if \
             --location japaneast \
@@ -68,6 +69,7 @@ jobs:
       - name: Bicep Deploy
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
+          SQL_ENTRA_ADMIN_OBJECT_ID: ${{ vars.AZURE_CLIENT_OBJECT_ID }}
         run: |
           az deployment sub create \
             --location japaneast \

--- a/infra/params/dev.bicepparam
+++ b/infra/params/dev.bicepparam
@@ -10,3 +10,5 @@ param logRetentionDays = 30
 param enablePurgeProtection = false
 param alertWebhookUrl = ''
 param sqlAdminPassword = readEnvironmentVariable('SQL_ADMIN_PASSWORD')
+param sqlEntraAdminLogin = readEnvironmentVariable('SQL_ENTRA_ADMIN_LOGIN', 'comical-github-oidc')
+param sqlEntraAdminObjectId = readEnvironmentVariable('SQL_ENTRA_ADMIN_OBJECT_ID')

--- a/infra/params/prod.bicepparam
+++ b/infra/params/prod.bicepparam
@@ -11,3 +11,5 @@ param logRetentionDays = 90
 param enablePurgeProtection = true
 param alertWebhookUrl = ''
 param sqlAdminPassword = readEnvironmentVariable('SQL_ADMIN_PASSWORD')
+param sqlEntraAdminLogin = readEnvironmentVariable('SQL_ENTRA_ADMIN_LOGIN', 'comical-github-oidc')
+param sqlEntraAdminObjectId = readEnvironmentVariable('SQL_ENTRA_ADMIN_OBJECT_ID')


### PR DESCRIPTION
## 問題

PR #229 マージ後の CD-Dev が Bicep What-If で失敗しました:

```
ERROR: BCP258: The following parameters are declared in the Bicep file
but are missing an assignment in the params file:
"sqlEntraAdminLogin", "sqlEntraAdminObjectId".
```

`.bicepparam` ファイルは **テンプレートで宣言されたすべてのパラメータを assign する必要があり**、CLI の `--parameters` 追加渡しでは解消できません。

## 修正

- `dev.bicepparam` / `prod.bicepparam` に環境変数経由で 2 パラメータを追加
  - `sqlEntraAdminLogin`: `SQL_ENTRA_ADMIN_LOGIN`（デフォルト `comical-github-oidc`）
  - `sqlEntraAdminObjectId`: `SQL_ENTRA_ADMIN_OBJECT_ID`
- `cd-dev.yml` / `cd-prod.yml` の冗長な `--parameters` 上書きを削除し、env 変数で渡す方式に統一
- ローカル `bicep build-params` で 9 パラメータすべて解決されることを確認済