### PR TITLE
fix(infra,cd): set SQL Entra admin via az CLI instead of Bicep

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -126,7 +126,6 @@ jobs:
         if: env.RUN_INFRA == 'true'
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
-          SQL_ENTRA_ADMIN_OBJECT_ID: ${{ vars.AZURE_CLIENT_OBJECT_ID }}
         run: |
           az deployment sub what-if \
             --location japaneast \
@@ -137,7 +136,6 @@ jobs:
         if: env.RUN_INFRA == 'true'
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
-          SQL_ENTRA_ADMIN_OBJECT_ID: ${{ vars.AZURE_CLIENT_OBJECT_ID }}
         run: |
           az deployment sub create \
             --location japaneast \
@@ -172,6 +170,24 @@ jobs:
           echo "apiApp=$API_APP" >> $GITHUB_OUTPUT
           echo "batchApp=$BATCH_APP" >> $GITHUB_OUTPUT
           echo "rg=$RG" >> $GITHUB_OUTPUT
+
+      - name: Set SQL Server Entra admin
+        # Idempotent. Required so the deploying SP can later issue
+        # CREATE USER FROM EXTERNAL PROVIDER against the database.
+        # Done via az CLI (not Bicep) because the inline 'administrators'
+        # block on Microsoft.Sql/servers conflicts on existing servers.
+        if: env.RUN_INFRA == 'true' || env.RUN_DB == 'true' || env.RUN_BACKEND == 'true'
+        run: |
+          set -euo pipefail
+          RG='${{ steps.outputs.outputs.rg }}'
+          SQL_FQDN='${{ steps.outputs.outputs.sqlFqdn }}'
+          SQL_SERVER="${SQL_FQDN%%.*}"
+          az sql server ad-admin create \
+            --resource-group "$RG" \
+            --server "$SQL_SERVER" \
+            --display-name 'comical-github-oidc' \
+            --object-id '${{ vars.AZURE_CLIENT_OBJECT_ID }}' \
+            -o none
 
       - name: DB Publish (sqlpackage)
         if: env.RUN_DB == 'true'

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Bicep What-If
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
-          SQL_ENTRA_ADMIN_OBJECT_ID: ${{ vars.AZURE_CLIENT_OBJECT_ID }}
         run: |
           az deployment sub what-if \
             --location japaneast \
@@ -69,7 +68,6 @@ jobs:
       - name: Bicep Deploy
         env:
           SQL_ADMIN_PASSWORD: ${{ secrets.SQL_ADMIN_PASSWORD }}
-          SQL_ENTRA_ADMIN_OBJECT_ID: ${{ vars.AZURE_CLIENT_OBJECT_ID }}
         run: |
           az deployment sub create \
             --location japaneast \
@@ -91,6 +89,21 @@ jobs:
           echo "apiApp=$API_APP" >> $GITHUB_OUTPUT
           echo "batchApp=$BATCH_APP" >> $GITHUB_OUTPUT
           echo "rg=$RG" >> $GITHUB_OUTPUT
+
+      - name: Set SQL Server Entra admin
+        # Idempotent. Required so the deploying SP can issue
+        # CREATE USER FROM EXTERNAL PROVIDER against the database.
+        run: |
+          set -euo pipefail
+          RG='${{ steps.outputs.outputs.rg }}'
+          SQL_FQDN='${{ steps.outputs.outputs.sqlFqdn }}'
+          SQL_SERVER="${SQL_FQDN%%.*}"
+          az sql server ad-admin create \
+            --resource-group "$RG" \
+            --server "$SQL_SERVER" \
+            --display-name 'comical-github-oidc' \
+            --object-id '${{ vars.AZURE_CLIENT_OBJECT_ID }}' \
+            -o none
 
       - name: DB Publish
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,148 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1' # 毎週月曜 03:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'src/backend/**'
+              - 'src/tests/backend/**'
+              - 'global.json'
+              - 'src/backend/Directory.Build.props'
+              - 'src/backend/Directory.Packages.props'
+            frontend:
+              - 'src/frontend/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.nvmrc'
+            workflows:
+              - '.github/workflows/codeql.yml'
+              - '.github/workflows/**'
+
+  analyze-csharp:
+    name: Analyze (csharp)
+    needs: changes
+    # On schedule and main push: always run (defense-in-depth full scan).
+    # On PRs: only when backend or any workflow changed.
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'push' ||
+      needs.changes.outputs.backend == 'true' ||
+      needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      contents: read
+      actions: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          global-json-file: global.json
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        with:
+          languages: csharp
+          build-mode: autobuild
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        with:
+          category: '/language:csharp'
+
+  analyze-js-ts:
+    name: Analyze (javascript-typescript)
+    needs: changes
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'push' ||
+      needs.changes.outputs.frontend == 'true' ||
+      needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      contents: read
+      actions: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        with:
+          languages: javascript-typescript
+          build-mode: none
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        with:
+          category: '/language:javascript-typescript'
+
+  analyze-actions:
+    name: Analyze (actions)
+    needs: changes
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'push' ||
+      needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      contents: read
+      actions: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        with:
+          languages: actions
+          build-mode: none
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+        with:
+          category: '/language:actions'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -19,12 +19,6 @@ param sqlAdminLogin string = 'sqladmin'
 @description('SQL Server administrator password — supply via CI/CD secret, not bicepparam')
 param sqlAdminPassword string
 
-@description('Entra ID admin login name on SQL Server (display name of the deploying SP)')
-param sqlEntraAdminLogin string
-
-@description('Entra ID admin object ID on SQL Server (the SP\'s objectId, not the appId)')
-param sqlEntraAdminObjectId string
-
 @description('Log Analytics workspace retention in days (30 for dev, 90 for prod)')
 param logRetentionDays int = 30
 
@@ -67,8 +61,6 @@ module data 'modules/data.bicep' = {
     sqlVCores: sqlVCores
     sqlAdminLogin: sqlAdminLogin
     sqlAdminPassword: sqlAdminPassword
-    sqlEntraAdminLogin: sqlEntraAdminLogin
-    sqlEntraAdminObjectId: sqlEntraAdminObjectId
   }
   dependsOn: [
     observability

--- a/infra/modules/data.bicep
+++ b/infra/modules/data.bicep
@@ -17,12 +17,6 @@ param sqlAdminLogin string = 'sqladmin'
 @description('SQL Server administrator password')
 param sqlAdminPassword string
 
-@description('Entra ID admin login name on SQL Server (display name of the principal — typically the deploying SP)')
-param sqlEntraAdminLogin string
-
-@description('Entra ID admin object ID on SQL Server (NOT the application/client ID)')
-param sqlEntraAdminObjectId string
-
 var sqlServerName = '${prefix}-${env}-jpe-sql'
 var sqlDatabaseName = '${prefix}-${env}-jpe-sqldb'
 // Storage account names must be lowercase alphanumeric, no hyphens, max 24 chars.
@@ -42,17 +36,6 @@ resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
     minimalTlsVersion: '1.2'
     // Allow Azure services to connect (required for Functions → SQL without VNet)
     publicNetworkAccess: 'Enabled'
-    // Entra (AAD) admin — required so the deploying SP can issue
-    // CREATE USER FROM EXTERNAL PROVIDER for Function App managed identities.
-    // SQL admin login is retained (azureADOnlyAuthentication: false) for sqlpackage DACPAC publish.
-    administrators: {
-      administratorType: 'ActiveDirectory'
-      principalType: 'Application'
-      login: sqlEntraAdminLogin
-      sid: sqlEntraAdminObjectId
-      tenantId: subscription().tenantId
-      azureADOnlyAuthentication: false
-    }
   }
 }
 

--- a/infra/params/dev.bicepparam
+++ b/infra/params/dev.bicepparam
@@ -10,5 +10,3 @@ param logRetentionDays = 30
 param enablePurgeProtection = false
 param alertWebhookUrl = ''
 param sqlAdminPassword = readEnvironmentVariable('SQL_ADMIN_PASSWORD')
-param sqlEntraAdminLogin = readEnvironmentVariable('SQL_ENTRA_ADMIN_LOGIN', 'comical-github-oidc')
-param sqlEntraAdminObjectId = readEnvironmentVariable('SQL_ENTRA_ADMIN_OBJECT_ID')

--- a/infra/params/prod.bicepparam
+++ b/infra/params/prod.bicepparam
@@ -11,5 +11,3 @@ param logRetentionDays = 90
 param enablePurgeProtection = true
 param alertWebhookUrl = ''
 param sqlAdminPassword = readEnvironmentVariable('SQL_ADMIN_PASSWORD')
-param sqlEntraAdminLogin = readEnvironmentVariable('SQL_ENTRA_ADMIN_LOGIN', 'comical-github-oidc')
-param sqlEntraAdminObjectId = readEnvironmentVariable('SQL_ENTRA_ADMIN_OBJECT_ID')


### PR DESCRIPTION
## 問題

PR #230 マージ後の CD-Dev が Bicep Deploy で失敗:

```
InvalidParameterValue: Invalid value given for parameter
AzureADOnlyAuthentication. Specify a valid parameter value.
```

`Microsoft.Sql/servers` の `administrators` インラインブロックは **create-time-only** に近く、既存サーバーへの update では ARM が `AzureADOnlyAuthentication` の値変更を拒否します。

## 修正

Bicep ではなく **az CLI で AAD admin を設定**する方針に切り替え:

- `data.bicep` / `main.bicep` / `*.bicepparam` の Entra admin 関連変更を **リバート**
- `cd-dev.yml` / `cd-prod.yml` に **"Set SQL Server Entra admin"** ステップを追加
  - `az sql server ad-admin create` は idempotent（同一 principal なら no-op）
- 不要になった `SQL_ENTRA_ADMIN_OBJECT_ID` env 変数を Bicep ステップから削除

repo variable `AZURE_CLIENT_OBJECT_ID` は新しい az ステップで引き続き使用。MI ユーザー作成・ロール付与の Grant ステップ（PR #229 で追加済）は変更なし。