### PR TITLE
fix(cd): derive SQL MI user SID from appId, not objectId

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -224,19 +224,53 @@ jobs:
           SQL_FQDN='${{ steps.outputs.outputs.sqlFqdn }}'
           SQL_DB='${{ steps.outputs.outputs.sqlDb }}'
 
+          # For Service Principals (Managed Identity included), Azure SQL
+          # expects the database user SID to be derived from the AAD
+          # *application ID* (appId) — NOT the principal/object ID.
+          # If we use the objectId, CREATE USER succeeds but the MI's
+          # token is rejected at login as "<token-identified principal>".
           API_PID=$(az functionapp identity show -g "$RG" -n "$API_APP" --query principalId -o tsv)
           BATCH_PID=$(az functionapp identity show -g "$RG" -n "$BATCH_APP" --query principalId -o tsv)
+          API_APPID=$(az ad sp show --id "$API_PID" --query appId -o tsv)
+          BATCH_APPID=$(az ad sp show --id "$BATCH_PID" --query appId -o tsv)
+
+          if [ -z "$API_APPID" ] || [ -z "$BATCH_APPID" ]; then
+            echo "Failed to resolve appId for one or both Function App MIs." >&2
+            echo "API_APPID=$API_APPID BATCH_APPID=$BATCH_APPID" >&2
+            exit 1
+          fi
 
           cat > /tmp/grant.sql <<SQL
           SET NOCOUNT ON;
-          DECLARE @apiName  sysname = N'$API_APP';
-          DECLARE @apiPid   uniqueidentifier = N'$API_PID';
-          DECLARE @bchName  sysname = N'$BATCH_APP';
-          DECLARE @bchPid   uniqueidentifier = N'$BATCH_PID';
+          DECLARE @apiName    sysname          = N'$API_APP';
+          DECLARE @apiAppId   uniqueidentifier = N'$API_APPID';
+          DECLARE @bchName    sysname          = N'$BATCH_APP';
+          DECLARE @bchAppId   uniqueidentifier = N'$BATCH_APPID';
+          DECLARE @apiSid     varbinary(16)    = CONVERT(varbinary(16), @apiAppId);
+          DECLARE @bchSid     varbinary(16)    = CONVERT(varbinary(16), @bchAppId);
+
+          -- If a user with the same name exists but with the wrong SID
+          -- (e.g. previously created from objectId), drop it so we can
+          -- recreate it with the correct appId-based SID.
+          IF EXISTS (
+              SELECT 1 FROM sys.database_principals
+              WHERE name = @apiName AND sid <> @apiSid
+          )
+          BEGIN
+              DECLARE @dropApi nvarchar(max) = N'DROP USER ' + QUOTENAME(@apiName);
+              EXEC sp_executesql @dropApi;
+          END;
+          IF EXISTS (
+              SELECT 1 FROM sys.database_principals
+              WHERE name = @bchName AND sid <> @bchSid
+          )
+          BEGIN
+              DECLARE @dropBch nvarchar(max) = N'DROP USER ' + QUOTENAME(@bchName);
+              EXEC sp_executesql @dropBch;
+          END;
 
           IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = @apiName)
           BEGIN
-              DECLARE @apiSid varbinary(16) = CONVERT(varbinary(16), @apiPid);
               DECLARE @apiSql nvarchar(max) = N'CREATE USER ' + QUOTENAME(@apiName)
                   + N' WITH SID = ' + CONVERT(nvarchar(100), @apiSid, 1) + N', TYPE = E';
               EXEC sp_executesql @apiSql;
@@ -244,7 +278,6 @@ jobs:
 
           IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = @bchName)
           BEGIN
-              DECLARE @bchSid varbinary(16) = CONVERT(varbinary(16), @bchPid);
               DECLARE @bchSql nvarchar(max) = N'CREATE USER ' + QUOTENAME(@bchName)
                   + N' WITH SID = ' + CONVERT(nvarchar(100), @bchSid, 1) + N', TYPE = E';
               EXEC sp_executesql @bchSql;


### PR DESCRIPTION
## 概要

Function App の Managed Identity が SQL Database へログインしようとすると、CREATE USER 自体は成功するのに

```
Login failed for user '<token-identified principal>'.
```

で拒否され続けていた。

## 原因

Azure SQL は **Service Principal**（Managed Identity 含む）の DB ユーザー SID を、principal の **objectId** ではなく **applicationId (appId)** から計算することを期待している。前 PR (#233) では `functionapp identity show --query principalId`（= objectId）から SID を生成していたため、CREATE USER は通るが MI が提示するトークンの SID と一致せずログインが弾かれていた。

## 修正

- 各 Function App MI の objectId から `az ad sp show --id <pid> --query appId` で appId を解決
- 既に誤った SID（objectId 由来）で作られているユーザーは DROP してから再作成
- `WITH SID = ...` には appId から作った SID を使用

## 検証

- 手動トリガー `POST /api/batch/trigger` 実行で App Insights の SqlException が消え、`DailyFetchOrchestrator` が success=True になることを確認する（CD-Dev 完了後）

## Refs

- #229 #230 #232 #233 の SQL MI 認証修正シリーズの最終ピース