### PR TITLE
fix(api): allow anonymous auth on Functions and configure SWA-linked Easy Auth

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -304,6 +304,13 @@ jobs:
               JOIN sys.database_principals r ON rm.role_principal_id = r.principal_id
               JOIN sys.database_principals m ON rm.member_principal_id = m.principal_id
               WHERE r.name = N'db_datawriter' AND m.name = @bchName) EXEC sp_executesql @addRoleBchW;
+
+          -- Grant EXECUTE on scalar functions / stored procs (e.g. dbo.fnToHiragana).
+          -- db_datareader / db_datawriter alone do NOT include EXECUTE.
+          DECLARE @grantApi nvarchar(max) = N'GRANT EXECUTE TO ' + QUOTENAME(@apiName);
+          DECLARE @grantBch nvarchar(max) = N'GRANT EXECUTE TO ' + QUOTENAME(@bchName);
+          EXEC sp_executesql @grantApi;
+          EXEC sp_executesql @grantBch;
           SQL
 
           # Authenticate via the active az CLI session (the OIDC SP that

--- a/infra/modules/app.bicep
+++ b/infra/modules/app.bicep
@@ -202,6 +202,51 @@ resource funcApi 'Microsoft.Web/sites@2024-04-01' = {
   ]
 }
 
+// API Function App authentication settings.
+// SWA-linked backend forwards anonymous requests to this Function App, and
+// each endpoint enforces required-auth checks via x-ms-client-principal
+// (see /me/* and /admin/* handlers). We must therefore keep Easy Auth
+// "enabled but unauthenticated-allowed" so that requests reach the Function
+// code. Without this, Azure Functions returns 401 Bearer challenges before
+// our middleware runs.
+resource funcApiAuthSettings 'Microsoft.Web/sites/config@2024-04-01' = {
+  parent: funcApi
+  name: 'authsettingsV2'
+  properties: {
+    platform: {
+      enabled: true
+      runtimeVersion: '~1'
+    }
+    globalValidation: {
+      requireAuthentication: false
+      unauthenticatedClientAction: 'AllowAnonymous'
+    }
+    httpSettings: {
+      requireHttps: true
+      routes: {
+        apiPrefix: '/.auth'
+      }
+      forwardProxy: {
+        convention: 'NoProxy'
+      }
+    }
+    identityProviders: {
+      azureStaticWebApps: {
+        enabled: true
+        registration: {
+          clientId: swa.properties.defaultHostname
+        }
+      }
+    }
+    login: {
+      tokenStore: {
+        enabled: false
+      }
+      preserveUrlFragmentsForLogins: false
+    }
+  }
+}
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Function App — Batch (Durable Functions, Consumption, separate plan)
 // ──────────────────────────────────────────────────────────────────────────────

--- a/src/backend/api/ComiCal.Api/Functions/AccountFunctions.cs
+++ b/src/backend/api/ComiCal.Api/Functions/AccountFunctions.cs
@@ -11,7 +11,7 @@ public static class AccountFunctions
 {
     [Function("DeleteAccount")]
     public static async Task<HttpResponseData> DeleteAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "v1/me/account/delete")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/me/account/delete")] HttpRequestData req,
         FunctionContext ctx,
         CancellationToken ct)
     {

--- a/src/backend/api/ComiCal.Api/Functions/AdminFunctions.cs
+++ b/src/backend/api/ComiCal.Api/Functions/AdminFunctions.cs
@@ -11,7 +11,7 @@ public static class AdminFunctions
 {
     [Function("GetBatchRuns")]
     public static async Task<HttpResponseData> GetBatchRunsAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "v1/admin/batch-runs")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/admin/batch-runs")] HttpRequestData req,
         FunctionContext ctx,
         CancellationToken ct)
     {
@@ -30,7 +30,7 @@ public static class AdminFunctions
 
     [Function("TriggerBatch")]
     public static async Task<HttpResponseData> TriggerBatchAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "v1/admin/batch/trigger")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/admin/batch/trigger")] HttpRequestData req,
         FunctionContext ctx,
         CancellationToken ct)
     {

--- a/src/backend/api/ComiCal.Api/Functions/PurchasesFunctions.cs
+++ b/src/backend/api/ComiCal.Api/Functions/PurchasesFunctions.cs
@@ -14,7 +14,7 @@ public static class PurchasesFunctions
 {
     [Function("UpdatePurchaseState")]
     public static async Task<HttpResponseData> UpdateAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "put", Route = "v1/me/purchases/{volumeId}")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "v1/me/purchases/{volumeId}")] HttpRequestData req,
         Guid volumeId,
         FunctionContext ctx,
         CancellationToken ct)

--- a/src/backend/api/ComiCal.Api/Functions/SeriesFunctions.cs
+++ b/src/backend/api/ComiCal.Api/Functions/SeriesFunctions.cs
@@ -13,7 +13,7 @@ public static class SeriesFunctions
 {
     [Function("SearchSeries")]
     public static async Task<HttpResponseData> SearchAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "v1/series")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/series")] HttpRequestData req,
         FunctionContext ctx,
         CancellationToken ct)
     {
@@ -40,7 +40,7 @@ public static class SeriesFunctions
 
     [Function("GetSeriesDetail")]
     public static async Task<HttpResponseData> GetDetailAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "v1/series/{id}")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/series/{id}")] HttpRequestData req,
         Guid id,
         FunctionContext ctx,
         CancellationToken ct)

--- a/src/backend/api/ComiCal.Api/Functions/SubscriptionsFunctions.cs
+++ b/src/backend/api/ComiCal.Api/Functions/SubscriptionsFunctions.cs
@@ -11,7 +11,7 @@ public static class SubscriptionsFunctions
 {
     [Function("GetSubscriptions")]
     public static async Task<HttpResponseData> GetAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "v1/me/subscriptions")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/me/subscriptions")] HttpRequestData req,
         FunctionContext ctx,
         CancellationToken ct)
     {
@@ -29,7 +29,7 @@ public static class SubscriptionsFunctions
 
     [Function("AddSubscription")]
     public static async Task<HttpResponseData> AddAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "v1/me/subscriptions")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/me/subscriptions")] HttpRequestData req,
         FunctionContext ctx,
         CancellationToken ct)
     {
@@ -60,7 +60,7 @@ public static class SubscriptionsFunctions
 
     [Function("RemoveSubscription")]
     public static async Task<HttpResponseData> RemoveAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "delete", Route = "v1/me/subscriptions/{seriesId}")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "v1/me/subscriptions/{seriesId}")] HttpRequestData req,
         Guid seriesId,
         FunctionContext ctx,
         CancellationToken ct)

--- a/src/backend/api/ComiCal.Api/Functions/SyncFunctions.cs
+++ b/src/backend/api/ComiCal.Api/Functions/SyncFunctions.cs
@@ -11,7 +11,7 @@ public static class SyncFunctions
 {
     [Function("UploadSyncQr")]
     public static async Task<HttpResponseData> UploadAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "v1/me/sync/qr")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "v1/me/sync/qr")] HttpRequestData req,
         FunctionContext ctx,
         CancellationToken ct)
     {
@@ -38,7 +38,7 @@ public static class SyncFunctions
 
     [Function("GetSyncQrData")]
     public static async Task<HttpResponseData> GetAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "v1/me/sync/qr/{token}")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/me/sync/qr/{token}")] HttpRequestData req,
         string token,
         FunctionContext ctx,
         CancellationToken ct)

--- a/src/backend/api/ComiCal.Api/Functions/VolumesFunctions.cs
+++ b/src/backend/api/ComiCal.Api/Functions/VolumesFunctions.cs
@@ -13,7 +13,7 @@ public static class VolumesFunctions
 {
     [Function("GetUpcomingVolumes")]
     public static async Task<HttpResponseData> GetUpcomingAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "v1/volumes/upcoming")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/volumes/upcoming")] HttpRequestData req,
         FunctionContext ctx,
         CancellationToken ct)
     {
@@ -33,7 +33,7 @@ public static class VolumesFunctions
 
     [Function("GetCalendarVolumes")]
     public static async Task<HttpResponseData> GetCalendarAsync(
-        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "v1/volumes/calendar")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "v1/volumes/calendar")] HttpRequestData req,
         FunctionContext ctx,
         CancellationToken ct)
     {


### PR DESCRIPTION
## 概要

SWA-linked backend 経由で Function App API を呼び出した際、Easy Auth が 401 Bearer challenge を返してしまい、`x-ms-client-principal` ベースの認可ミドルウェアまでリクエストが到達しない問題を修正します。

## 変更内容

### `src/backend/api/ComiCal.Api/Functions/*.cs`
- 全 HTTP トリガーの `AuthorizationLevel` を `Function` → `Anonymous` に変更。
- 認可は SWA から転送される `x-ms-client-principal` ヘッダで各エンドポイント（`/me/*`, `/admin/*`）が実施するため、Functions ホスト側のキー認証は不要。

### `infra/modules/app.bicep`
- API Function App に `authsettingsV2` を追加。
  - `requireAuthentication: false` / `unauthenticatedClientAction: AllowAnonymous` で Easy Auth は「有効だが匿名許可」状態に。
  - `azureStaticWebApps` Identity Provider を登録し、SWA-linked リクエストの principal をパススルー。
- これにより 401 Bearer challenge を抑制し、リクエストを Function コードまで通す。

### `.github/workflows/cd-dev.yml`
- API/Batch SQL ユーザーに `GRANT EXECUTE` を付与。
- `db_datareader` / `db_datawriter` には EXECUTE が含まれないため、`dbo.fnToHiragana` などのスカラー関数呼び出しが失敗していた。

## 検証

- `dotnet build src/backend/api/ComiCal.Api/ComiCal.Api.csproj` ✅ 0 warnings / 0 errors
- `dotnet test src/backend/ComiCal.slnx` ✅ 132 passed / 0 failed
- `bicep build infra/main.bicep` ✅ 成功（既存の `core.windows.net` ハードコード警告のみ、本 PR とは無関係）

## 影響範囲

- バックエンド API の認可レイヤ（Functions → ミドルウェア）
- Dev 環境の Function App Easy Auth 設定
- CD パイプラインでの SQL ユーザー権限付与