### PR TITLE
fix(blob): drop duplicate 'covers/' prefix from ThumbnailAsset.BlobKey

### DIFF
--- a/src/backend/infrastructure/ComiCal.Infrastructure.Blob/BlobStorageService.cs
+++ b/src/backend/infrastructure/ComiCal.Infrastructure.Blob/BlobStorageService.cs
@@ -24,7 +24,10 @@ public sealed class BlobStorageService(BlobServiceClient blobServiceClient)
             return null; // unchanged
 
         var blobName = Convert.ToHexString(hash).ToLowerInvariant() + ".jpg";
-        var blobKey = $"covers/{blobName}";
+        // BlobKey is the path within the container (e.g. "<hash>.jpg").
+        // The container name ("covers") is already part of BlobBaseUrl, so do NOT
+        // include it here — otherwise the public URL becomes ".../covers/covers/...".
+        var blobKey = blobName;
         var container = blobServiceClient.GetBlobContainerClient(CoversContainer);
         var blob = container.GetBlobClient(blobName);
 

--- a/src/db/ComiCal.Database.sqlproj
+++ b/src/db/ComiCal.Database.sqlproj
@@ -24,6 +24,7 @@
     <None Include="Scripts\PostDeploy\01-seed-reference-data.sql" />
     <None Include="Scripts\PostDeploy\02-seed-admin-user.sql" />
     <None Include="Scripts\PostDeploy\03-fulltext-indexes.sql" />
+    <None Include="Scripts\PostDeploy\04-fix-thumbnail-blobkey.sql" />
     <None Include="Scripts\Seed\dev-sample-series.sql" />
   </ItemGroup>
 </Project>

--- a/src/db/Scripts/PostDeploy/04-fix-thumbnail-blobkey.sql
+++ b/src/db/Scripts/PostDeploy/04-fix-thumbnail-blobkey.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- One-time data fix: strip stale "covers/" prefix from ThumbnailAssets.BlobKey.
+--
+-- Background:
+--   Earlier versions of BlobStorageService stored BlobKey as "covers/<hash>.jpg"
+--   while BlobBaseUrl already contains the container path
+--   (e.g. https://<account>.blob.core.windows.net/covers). The mapper concatenates
+--   "<BlobBaseUrl>/<BlobKey>", which produced ".../covers/covers/<hash>.jpg" → 404.
+--
+--   The code has been fixed to write BlobKey as "<hash>.jpg" only. This script
+--   normalizes any rows that were persisted with the legacy prefix.
+--
+-- Idempotency:
+--   The WHERE clause limits the UPDATE to rows still carrying the legacy prefix,
+--   so re-running the script is a no-op.
+-- ============================================================================
+
+UPDATE dbo.ThumbnailAssets
+SET BlobKey = SUBSTRING(BlobKey, LEN(N'covers/') + 1, 4000)
+WHERE BlobKey LIKE N'covers/%';

--- a/src/db/Scripts/PostDeploy/Script.PostDeployment.sql
+++ b/src/db/Scripts/PostDeploy/Script.PostDeployment.sql
@@ -1,3 +1,4 @@
 :r .\01-seed-reference-data.sql
 :r .\02-seed-admin-user.sql
 :r .\03-fulltext-indexes.sql
+:r .\04-fix-thumbnail-blobkey.sql


### PR DESCRIPTION
## 概要

書影サムネイルの公開 URL が `.../covers/covers/<hash>.jpg` と二重になり 404 を返していた問題を修正します。

## 現象

Dev SWA のホームに直近発売予定の表紙画像が一切表示されない。API レスポンスの `thumbnailUrl` を `curl` した結果:

\`\`\`text
GET https://cmcldevjpest.blob.core.windows.net/covers/covers/<hash>.jpg
HTTP/1.1 404 The specified blob does not exist.
\`\`\`

実体は \`covers/<hash>.jpg\` 直下に存在します。

## 原因

\`BlobStorageService.UploadThumbnailIfChangedAsync\` が \`BlobKey = \"covers/<hash>.jpg\"\` を保存していた一方で、Function App の \`BlobBaseUrl\` 環境変数は \`https://<account>.blob.core.windows.net/covers\`（コンテナ名込み、\`infra/modules/app.bicep\`）。\`VolumeMapper.ToDto\` で連結すると \`covers\` が二重になります。

## 変更

### \`src/backend/infrastructure/ComiCal.Infrastructure.Blob/BlobStorageService.cs\`
- \`BlobKey\` をコンテナ内パス（\`<hash>.jpg\`）のみで保存するよう修正。コメントで意図を明記。

### \`src/db/Scripts/PostDeploy/04-fix-thumbnail-blobkey.sql\` (新規)
- 既存行の \`BlobKey\` から先頭の \`covers/\` を除去する idempotent な \`UPDATE\`。
- \`WHERE BlobKey LIKE N'covers/%'\` で再実行しても no-op。
- \`Script.PostDeployment.sql\` から \`:r\` で取り込み、\`.sqlproj\` に \`<None Include>\` 登録。

## 検証

- \`dotnet build src/backend/ComiCal.slnx\` ✅ 0 warnings / 0 errors
- \`dotnet test src/backend/ComiCal.slnx\` ✅ 132 passed / 0 failed
- \`dotnet build src/db/ComiCal.Database.sqlproj\` ✅ DACPAC ビルド成功
- 既存テストの \`BlobKey\` 形式を検証するアサーションは存在せず、互換性に影響なし

## 影響範囲

- バックエンド: 新規アップロード以降の \`BlobKey\` の値（短くなる）
- DB: dev デプロイ時に既存の \`covers/...\` プレフィックス付き行が一度だけ正規化される
- フロントエンド: 表示変更なし（API レスポンスの \`thumbnailUrl\` が正しく解決されるようになる）

## 関連

- 別 PR \#235 (\`fix(api): allow anonymous auth on Functions\`) と独立した別不具合