### PR TITLE
fix(cd): deploy directly to Function App (Flex Consumption has no slots)

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -136,12 +136,14 @@ jobs:
           cd publish/api && zip -r ../../api.zip . && cd ../..
           cd publish/batch && zip -r ../../batch.zip . && cd ../..
 
-      - name: Deploy API to Azure Functions (staging slot)
+      # NOTE: Function Apps run on Flex Consumption (FC1), which does not
+      # support deployment slots. Deploy directly to the production app
+      # (same approach as cd-dev.yml).
+      - name: Deploy API to Azure Functions
         run: |
           az functionapp deployment source config-zip \
             --resource-group "${{ steps.outputs.outputs.rg }}" \
             --name "${{ steps.outputs.outputs.apiApp }}" \
-            --slot staging \
             --src api.zip
 
       - name: Deploy Batch to Azure Functions
@@ -150,14 +152,6 @@ jobs:
             --resource-group "${{ steps.outputs.outputs.rg }}" \
             --name "${{ steps.outputs.outputs.batchApp }}" \
             --src batch.zip
-
-      - name: Swap staging → production slot
-        run: |
-          az functionapp deployment slot swap \
-            --resource-group "${{ steps.outputs.outputs.rg }}" \
-            --name "${{ steps.outputs.outputs.apiApp }}" \
-            --slot staging \
-            --target-slot production
 
       - name: Deploy Frontend to SWA
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1


### PR DESCRIPTION
## 背景

`v2.0.0` リリース時の CD - Prod が以下のエラーで失敗:

```
ERROR: (ResourceNotFound) The Resource 'Microsoft.Web/sites/cmcl-prod-jpe-func-api/slots/staging' under resource group 'cmcl-prod-jpe-rg' was not found.
```

## 原因

Function App は Bicep (`infra/modules/app.bicep`) で **Flex Consumption (FC1)** プランで定義されているが、Flex Consumption は **デプロイメントスロット非対応**。`cd-prod.yml` の staging slot → swap 方式が成立しない。

## 修正

staging slot へのデプロイ＋ swap を削除し、`cd-dev.yml` と同様に Function App へ直接 zip デプロイする方式に変更。

## 影響

- 一時的に Blue/Green ダウンタイム最小化は失われる（zip デプロイ中の数秒のコールドスタート）。
- 将来 Premium / Dedicated plan に切り替えた時点で slot 方式を再導入する選択肢は残る。

## 検証

- 次回の `v*` タグ push (または CD - Prod 手動実行) でデプロイ成功すること。