### PR TITLE
fix(cd): grant Function App MIs DB access in prod (mirror cd-dev.yml)

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -121,6 +121,119 @@ jobs:
             /p:BlockOnPossibleDataLoss=true \
             /p:BackupDatabaseBeforeChanges=false
 
+      - name: Grant Function MIs DB access
+        # Idempotently CREATE USER FROM EXTERNAL PROVIDER (via SID) and grant
+        # db_datareader / db_datawriter to the API and Batch Function App MIs.
+        # Mirrors the equivalent step in cd-dev.yml.
+        run: |
+          set -euo pipefail
+          # Install go-sqlcmd (single static binary; uses az CLI session for AAD auth)
+          curl -sSL -o /tmp/sqlcmd.tar.bz2 \
+            https://github.com/microsoft/go-sqlcmd/releases/download/v1.8.0/sqlcmd-linux-amd64.tar.bz2
+          mkdir -p /tmp/sqlcmd && tar -xjf /tmp/sqlcmd.tar.bz2 -C /tmp/sqlcmd
+          SQLCMD=/tmp/sqlcmd/sqlcmd
+
+          RG='${{ steps.outputs.outputs.rg }}'
+          API_APP='${{ steps.outputs.outputs.apiApp }}'
+          BATCH_APP='${{ steps.outputs.outputs.batchApp }}'
+          SQL_FQDN='${{ steps.outputs.outputs.sqlFqdn }}'
+          SQL_DB='${{ steps.outputs.outputs.sqlDb }}'
+
+          # For Service Principals (Managed Identity included), Azure SQL
+          # expects the database user SID to be derived from the AAD
+          # *application ID* (appId) — NOT the principal/object ID.
+          # If we use the objectId, CREATE USER succeeds but the MI's
+          # token is rejected at login as "<token-identified principal>".
+          API_PID=$(az functionapp identity show -g "$RG" -n "$API_APP" --query principalId -o tsv)
+          BATCH_PID=$(az functionapp identity show -g "$RG" -n "$BATCH_APP" --query principalId -o tsv)
+          API_APPID=$(az ad sp show --id "$API_PID" --query appId -o tsv)
+          BATCH_APPID=$(az ad sp show --id "$BATCH_PID" --query appId -o tsv)
+
+          if [ -z "$API_APPID" ] || [ -z "$BATCH_APPID" ]; then
+            echo "Failed to resolve appId for one or both Function App MIs." >&2
+            echo "API_APPID=$API_APPID BATCH_APPID=$BATCH_APPID" >&2
+            exit 1
+          fi
+
+          cat > /tmp/grant.sql <<SQL
+          SET NOCOUNT ON;
+          DECLARE @apiName    sysname          = N'$API_APP';
+          DECLARE @apiAppId   uniqueidentifier = N'$API_APPID';
+          DECLARE @bchName    sysname          = N'$BATCH_APP';
+          DECLARE @bchAppId   uniqueidentifier = N'$BATCH_APPID';
+          DECLARE @apiSid     varbinary(16)    = CONVERT(varbinary(16), @apiAppId);
+          DECLARE @bchSid     varbinary(16)    = CONVERT(varbinary(16), @bchAppId);
+
+          -- If a user with the same name exists but with the wrong SID
+          -- (e.g. previously created from objectId), drop it so we can
+          -- recreate it with the correct appId-based SID.
+          IF EXISTS (
+              SELECT 1 FROM sys.database_principals
+              WHERE name = @apiName AND sid <> @apiSid
+          )
+          BEGIN
+              DECLARE @dropApi nvarchar(max) = N'DROP USER ' + QUOTENAME(@apiName);
+              EXEC sp_executesql @dropApi;
+          END;
+          IF EXISTS (
+              SELECT 1 FROM sys.database_principals
+              WHERE name = @bchName AND sid <> @bchSid
+          )
+          BEGIN
+              DECLARE @dropBch nvarchar(max) = N'DROP USER ' + QUOTENAME(@bchName);
+              EXEC sp_executesql @dropBch;
+          END;
+
+          IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = @apiName)
+          BEGIN
+              DECLARE @apiSql nvarchar(max) = N'CREATE USER ' + QUOTENAME(@apiName)
+                  + N' WITH SID = ' + CONVERT(nvarchar(100), @apiSid, 1) + N', TYPE = E';
+              EXEC sp_executesql @apiSql;
+          END;
+
+          IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = @bchName)
+          BEGIN
+              DECLARE @bchSql nvarchar(max) = N'CREATE USER ' + QUOTENAME(@bchName)
+                  + N' WITH SID = ' + CONVERT(nvarchar(100), @bchSid, 1) + N', TYPE = E';
+              EXEC sp_executesql @bchSql;
+          END;
+
+          DECLARE @addRoleApiR  nvarchar(max) = N'ALTER ROLE db_datareader ADD MEMBER ' + QUOTENAME(@apiName);
+          DECLARE @addRoleApiW  nvarchar(max) = N'ALTER ROLE db_datawriter ADD MEMBER ' + QUOTENAME(@apiName);
+          DECLARE @addRoleBchR  nvarchar(max) = N'ALTER ROLE db_datareader ADD MEMBER ' + QUOTENAME(@bchName);
+          DECLARE @addRoleBchW  nvarchar(max) = N'ALTER ROLE db_datawriter ADD MEMBER ' + QUOTENAME(@bchName);
+
+          IF NOT EXISTS (SELECT 1 FROM sys.database_role_members rm
+              JOIN sys.database_principals r ON rm.role_principal_id = r.principal_id
+              JOIN sys.database_principals m ON rm.member_principal_id = m.principal_id
+              WHERE r.name = N'db_datareader' AND m.name = @apiName) EXEC sp_executesql @addRoleApiR;
+          IF NOT EXISTS (SELECT 1 FROM sys.database_role_members rm
+              JOIN sys.database_principals r ON rm.role_principal_id = r.principal_id
+              JOIN sys.database_principals m ON rm.member_principal_id = m.principal_id
+              WHERE r.name = N'db_datawriter' AND m.name = @apiName) EXEC sp_executesql @addRoleApiW;
+          IF NOT EXISTS (SELECT 1 FROM sys.database_role_members rm
+              JOIN sys.database_principals r ON rm.role_principal_id = r.principal_id
+              JOIN sys.database_principals m ON rm.member_principal_id = m.principal_id
+              WHERE r.name = N'db_datareader' AND m.name = @bchName) EXEC sp_executesql @addRoleBchR;
+          IF NOT EXISTS (SELECT 1 FROM sys.database_role_members rm
+              JOIN sys.database_principals r ON rm.role_principal_id = r.principal_id
+              JOIN sys.database_principals m ON rm.member_principal_id = m.principal_id
+              WHERE r.name = N'db_datawriter' AND m.name = @bchName) EXEC sp_executesql @addRoleBchW;
+
+          -- Grant EXECUTE on scalar functions / stored procs (e.g. dbo.fnToHiragana).
+          -- db_datareader / db_datawriter alone do NOT include EXECUTE.
+          DECLARE @grantApi nvarchar(max) = N'GRANT EXECUTE TO ' + QUOTENAME(@apiName);
+          DECLARE @grantBch nvarchar(max) = N'GRANT EXECUTE TO ' + QUOTENAME(@bchName);
+          EXEC sp_executesql @grantApi;
+          EXEC sp_executesql @grantBch;
+          SQL
+
+          # Authenticate via the active az CLI session (the OIDC SP that
+          # was just set as the SQL Entra admin in the previous step).
+          $SQLCMD -S "$SQL_FQDN" -d "$SQL_DB" \
+            --authentication-method ActiveDirectoryAzCli \
+            -i /tmp/grant.sql -b
+
       - name: Build All
         run: |
           dotnet build src/backend/ComiCal.slnx --configuration Release


### PR DESCRIPTION
## 背景

`v2.0.0` リリース後、Web UI から検索 API が 500 を返した。Batch 手動起動 (`/api/batch/trigger`) も Activity `CreateBatchRunActivity` で SQL ログイン失敗:

```
Login failed for user '<token-identified principal>'
```

## 原因

API / Batch Function App の Managed Identity が prod の Azure SQL DB に **contained user として登録されていない**。`cd-dev.yml` には `Grant Function MIs DB access` ステップがあるが、`cd-prod.yml` には欠落していた。

## 修正

`cd-dev.yml` の同名ステップを `cd-prod.yml` に移植。

- principalId → appId に変換し、appId 由来の SID で `CREATE USER FROM EXTERNAL PROVIDER`
- `db_datareader` / `db_datawriter` ロール付与
- スカラー関数 (`dbo.fnToHiragana` 等) 用に `GRANT EXECUTE`
- 既存ユーザーの SID 不一致時は DROP→再作成（冪等）

## 検証

マージ後、`workflow_dispatch` で CD - Prod を実行し、Batch 手動起動 → 検索 API が 200 を返すこと。