### PR TITLE
fix(infra): add RakutenApplicationId app setting to API Function App

### DIFF
--- a/infra/modules/app.bicep
+++ b/infra/modules/app.bicep
@@ -191,6 +191,10 @@ resource funcApi 'Microsoft.Web/sites@2024-04-01' = {
           value: 'https://${storageAccountName}.blob.core.windows.net/covers'
         }
         {
+          name: 'RakutenApplicationId'
+          value: '@Microsoft.KeyVault(SecretUri=${kv.properties.vaultUri}secrets/RakutenAppId/)'
+        }
+        {
           name: 'AppConfiguration__Endpoint'
           value: 'https://${appConfigName}.azconfig.io'
         }


### PR DESCRIPTION
## 背景

PR #251 で検索 API (`GET /api/v1/series`) が楽天 Books API へフォールバック呼び出しするようになったが、bicep の API Function App (`funcApi`) の `siteConfig.appSettings` に `RakutenApplicationId` が無く、Dev 環境にデプロイ後も `rakutenCandidates` が常に空配列になっていた。Batch 側 (`funcBatch`) には同等の設定が既に存在していたため、対称になるよう API 側にも追加する。

## 変更

- `infra/modules/app.bicep` の `funcApi` の `appSettings` に `RakutenApplicationId` を追加（KV `RakutenAppId` 参照）

## 動作確認

Dev 環境で az CLI から手動で同設定を入れて検証済み:

```bash
curl 'https://white-pond-0814e3300.7.azurestaticapps.net/api/v1/series?q=軍靴のバルツァー'
# → rakutenCandidates に楽天 Books 検索結果が返る
```

ブラウザでも検索画面に「楽天 Books の候補（未登録）」セクションが正しく表示されることを確認。

## 関連

- #251 (Rakuten フォールバック検索の機能追加)