### PR TITLE
fix: Azure SQL Serverless auto-pause 復旧時の接続タイムアウトとクライアントリトライを対応

### DIFF
--- a/src/backend/infrastructure/ComiCal.Infrastructure.Sql/ServiceCollectionExtensions.cs
+++ b/src/backend/infrastructure/ComiCal.Infrastructure.Sql/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using ComiCal.Domain.Repositories;
 using ComiCal.Infrastructure.Sql.Repositories;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -10,8 +11,12 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddSqlInfrastructure(
         this IServiceCollection services, string connectionString)
     {
+        // Azure SQL Serverless の自動一時停止からの復旧に備え ConnectTimeout を延長する。
+        // デフォルト 30 秒では auto-resume が間に合わず post-login タイムアウトが発生するため 90 秒に設定。
+        var csb = new SqlConnectionStringBuilder(connectionString) { ConnectTimeout = 90 };
+
         services.AddDbContext<ComiCalDbContext>(options =>
-            options.UseSqlServer(connectionString, sqlOptions =>
+            options.UseSqlServer(csb.ConnectionString, sqlOptions =>
             {
                 sqlOptions.EnableRetryOnFailure(3);
                 sqlOptions.CommandTimeout(30);

--- a/src/frontend/src/app/app.config.ts
+++ b/src/frontend/src/app/app.config.ts
@@ -16,7 +16,12 @@ export const appConfig: ApplicationConfig = {
     provideClientHydration(withEventReplay()),
     provideHttpClient(
       withFetch(),
-      withInterceptors([authInterceptor, errorInterceptor, retryInterceptor, transferStateInterceptor]),
+      withInterceptors([
+        authInterceptor,
+        errorInterceptor,
+        retryInterceptor,
+        transferStateInterceptor,
+      ]),
     ),
     provideApiClient(),
   ],

--- a/src/frontend/src/app/app.config.ts
+++ b/src/frontend/src/app/app.config.ts
@@ -5,6 +5,7 @@ import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/
 import { routes } from './app.routes';
 import { authInterceptor } from './core/auth/auth.interceptor';
 import { errorInterceptor } from './core/http/error.interceptor';
+import { retryInterceptor } from './core/http/retry.interceptor';
 import { transferStateInterceptor } from './core/http/transfer-state.interceptor';
 import { provideApiClient } from './core/api';
 
@@ -15,7 +16,7 @@ export const appConfig: ApplicationConfig = {
     provideClientHydration(withEventReplay()),
     provideHttpClient(
       withFetch(),
-      withInterceptors([authInterceptor, errorInterceptor, transferStateInterceptor]),
+      withInterceptors([authInterceptor, errorInterceptor, retryInterceptor, transferStateInterceptor]),
     ),
     provideApiClient(),
   ],

--- a/src/frontend/src/app/core/http/retry.interceptor.spec.ts
+++ b/src/frontend/src/app/core/http/retry.interceptor.spec.ts
@@ -1,0 +1,90 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { HttpClient } from '@angular/common/http';
+import { PLATFORM_ID } from '@angular/core';
+import { retryInterceptor } from './retry.interceptor';
+
+describe('retryInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+
+  function setup(platformId = 'browser') {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([retryInterceptor])),
+        provideHttpClientTesting(),
+        { provide: PLATFORM_ID, useValue: platformId },
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  }
+
+  afterEach(() => {
+    httpMock.verify();
+    TestBed.resetTestingModule();
+  });
+
+  it('500 が続く場合は最大3回リトライして最終的にエラーを返す', fakeAsync(() => {
+    setup();
+    let errorCaught = false;
+    http.get('/api/test').subscribe({ error: () => (errorCaught = true) });
+
+    // 初回 + 3リトライ = 計4リクエスト
+    httpMock.expectOne('/api/test').flush('err', { status: 500, statusText: 'Server Error' });
+    tick(1000);
+    httpMock.expectOne('/api/test').flush('err', { status: 500, statusText: 'Server Error' });
+    tick(2000);
+    httpMock.expectOne('/api/test').flush('err', { status: 500, statusText: 'Server Error' });
+    tick(4000);
+    httpMock.expectOne('/api/test').flush('err', { status: 500, statusText: 'Server Error' });
+
+    expect(errorCaught).toBe(true);
+  }));
+
+  it('503 後のリトライで成功した場合はレスポンスを返す', fakeAsync(() => {
+    setup();
+    let result: unknown;
+    http.get('/api/test').subscribe({ next: (r) => (result = r) });
+
+    // 初回失敗
+    httpMock.expectOne('/api/test').flush('err', { status: 503, statusText: 'Service Unavailable' });
+    tick(1000);
+    // リトライ成功
+    httpMock.expectOne('/api/test').flush({ items: [] });
+
+    expect(result).toEqual({ items: [] });
+  }));
+
+  it('404 はリトライしない', fakeAsync(() => {
+    setup();
+    let errorCaught = false;
+    http.get('/api/test').subscribe({ error: () => (errorCaught = true) });
+
+    httpMock.expectOne('/api/test').flush('not found', { status: 404, statusText: 'Not Found' });
+
+    expect(errorCaught).toBe(true);
+    // 追加リクエストなし（verify で確認）
+  }));
+
+  it('POSTリクエストはリトライしない', fakeAsync(() => {
+    setup();
+    let errorCaught = false;
+    http.post('/api/test', {}).subscribe({ error: () => (errorCaught = true) });
+
+    httpMock.expectOne('/api/test').flush('err', { status: 500, statusText: 'Server Error' });
+
+    expect(errorCaught).toBe(true);
+  }));
+
+  it('SSR（server platformId）ではリトライしない', fakeAsync(() => {
+    setup('server');
+    let errorCaught = false;
+    http.get('/api/test').subscribe({ error: () => (errorCaught = true) });
+
+    httpMock.expectOne('/api/test').flush('err', { status: 503, statusText: 'Service Unavailable' });
+
+    expect(errorCaught).toBe(true);
+  }));
+});

--- a/src/frontend/src/app/core/http/retry.interceptor.spec.ts
+++ b/src/frontend/src/app/core/http/retry.interceptor.spec.ts
@@ -49,7 +49,9 @@ describe('retryInterceptor', () => {
     http.get('/api/test').subscribe({ next: (r) => (result = r) });
 
     // 初回失敗
-    httpMock.expectOne('/api/test').flush('err', { status: 503, statusText: 'Service Unavailable' });
+    httpMock
+      .expectOne('/api/test')
+      .flush('err', { status: 503, statusText: 'Service Unavailable' });
     tick(1000);
     // リトライ成功
     httpMock.expectOne('/api/test').flush({ items: [] });
@@ -83,7 +85,9 @@ describe('retryInterceptor', () => {
     let errorCaught = false;
     http.get('/api/test').subscribe({ error: () => (errorCaught = true) });
 
-    httpMock.expectOne('/api/test').flush('err', { status: 503, statusText: 'Service Unavailable' });
+    httpMock
+      .expectOne('/api/test')
+      .flush('err', { status: 503, statusText: 'Service Unavailable' });
 
     expect(errorCaught).toBe(true);
   }));

--- a/src/frontend/src/app/core/http/retry.interceptor.ts
+++ b/src/frontend/src/app/core/http/retry.interceptor.ts
@@ -1,0 +1,40 @@
+import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
+import { inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { retry, timer } from 'rxjs';
+
+/** 一時的なサーバー障害とみなしてリトライするステータスコード */
+const RETRYABLE_STATUS_CODES = new Set([500, 503, 504]);
+
+/** 最大リトライ回数 */
+const MAX_RETRIES = 3;
+
+/**
+ * GETリクエストに対して指数バックオフでリトライするインターセプター。
+ *
+ * - SSR中はリトライしない（初回レンダリングはフェイルファストで十分）
+ * - GET以外（POST/PUT/DELETE等）はリトライしない（冪等でないため）
+ * - 500/503/504 のみ対象（4xx 等クライアントエラーはリトライ不要）
+ * - バックオフ: 1s → 2s → 4s（最大3回）
+ *
+ * Azure SQL Serverless の auto-pause 復旧時に API が一時的に 500/503 を返す
+ * ケースを吸収する目的で導入。
+ */
+export const retryInterceptor: HttpInterceptorFn = (req, next) => {
+  const platformId = inject(PLATFORM_ID);
+
+  if (!isPlatformBrowser(platformId)) return next(req);
+  if (req.method !== 'GET') return next(req);
+
+  return next(req).pipe(
+    retry({
+      count: MAX_RETRIES,
+      delay: (error, attempt) => {
+        if (!(error instanceof HttpErrorResponse) || !RETRYABLE_STATUS_CODES.has(error.status)) {
+          throw error;
+        }
+        return timer(1000 * Math.pow(2, attempt - 1)); // 1s, 2s, 4s
+      },
+    }),
+  );
+};


### PR DESCRIPTION
## 問題

本番環境 (cmcl-prod-jpe-appi) で SQL 接続タイムアウトが発生。

| 項目 | 内容 |
|---|---|
| 発生時刻 | 2026-05-11T04:09:56Z |
| 対象 Function | `GetUpcomingVolumes` |
| エラー | `[Post-Login] complete=29193ms` |
| 原因 | Azure SQL Serverless の auto-pause 復旧に 30 秒以上かかり、デフォルトの Connect Timeout (30 秒) を超過 |

## 対応内容

### Backend — ConnectTimeout 延長
- `ServiceCollectionExtensions.cs`: `SqlConnectionStringBuilder` で `ConnectTimeout=90` に延長
- auto-resume には通常 20〜60 秒かかるため、1 回の接続試行で吸収できるようになる
- `EnableRetryOnFailure(3)` は既存のまま維持

### Frontend — クライアントリトライ (`retryInterceptor`)
- GET のみ対象（POST/PUT/DELETE は冪等でないためスキップ）
- 対象ステータス: 500 / 503 / 504（一時的なサーバー障害のみ）
- 最大 3 回、指数バックオフ: 1s → 2s → 4s
- SSR 中はリトライしない
- interceptor 順序: `[auth, **error**, **retry**, transferState]`
  → 全リトライ失敗後のみ `errorInterceptor` がトーストを表示

## テスト
- `retry.interceptor.spec.ts` を新規追加（5 ケース全通過）

## 多層防御の構造

```
[DB auto-resume]
  ↑ ConnectTimeout=90s で1接続試行内に吸収
  ↑ EnableRetryOnFailure(3) で DB エラーをリトライ
  ↑ retryInterceptor (FE) で API 500/503/504 をリトライ（1s→2s→4s）
  ↑ 全て失敗 → ToastService でエラー表示
```