### PR TITLE
chore(deps): add Dependabot cooldown to mitigate supply-chain risk

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,6 +95,10 @@ az deployment sub what-if -l japaneast -f infra/main.bicep -p infra/params/dev.b
 - **テナンシー**: シングルテナント、`UserId` 列で論理分離
 - **リソース命名**: CAF 推奨 `{prefix}-{env}-{region}-{resource}`
 - **WCAG 2.1 AA 遵拠**
+- **依存パッケージの更新は「公開から 7 日以上経過したバージョン」を原則とする**（`.github/dependabot.yml` の `cooldown` 設定を参照）。サプライチェーン攻撃（乗っ取られたパッケージが公開直後に配布され、数時間〜数日で発覚・撤回されるケースが大半）への対策。
+  - ⚠️ **AI エージェント（Copilot coding agent / Copilot CLI 等）向け注意**: 依存パッケージのバージョンを手動で `@latest` 相当に上げる、あるいは npm/NuGet で新規パッケージをインストールする作業を行う際は、そのバージョンの公開日を確認し、**公開から 7 日未満のバージョンには極力更新しない**こと。Dependabot の `cooldown` は Dependabot 自身が作成する PR にしか効かず、エージェントが `npm install pkg@latest` 等で直接手動更新する操作は保護対象外のため、エージェント自身がこのルールを尊重する必要がある。
+  - ただし、既知の CVE（GitHub Security Advisory / Dependabot Alert で特定されたもの）を修正するための緊急パッチ適用はこの限りではなく、cooldown を待たず速やかに対応する。
+  - AI が生成したパッケージ名をそのままインストールしない（"slopsquatting" 対策）。パッケージ名は公式レジストリ（npmjs.com / nuget.org）で実在と提供元を必ず確認する。
 
 ## Pre-checkin Validation Steps
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,10 +95,16 @@ az deployment sub what-if -l japaneast -f infra/main.bicep -p infra/params/dev.b
 - **テナンシー**: シングルテナント、`UserId` 列で論理分離
 - **リソース命名**: CAF 推奨 `{prefix}-{env}-{region}-{resource}`
 - **WCAG 2.1 AA 遵拠**
-- **依存パッケージの更新は「公開から 7 日以上経過したバージョン」を原則とする**（`.github/dependabot.yml` の `cooldown` 設定を参照）。サプライチェーン攻撃（乗っ取られたパッケージが公開直後に配布され、数時間〜数日で発覚・撤回されるケースが大半）への対策。
-  - ⚠️ **AI エージェント（Copilot coding agent / Copilot CLI 等）向け注意**: 依存パッケージのバージョンを手動で `@latest` 相当に上げる、あるいは npm/NuGet で新規パッケージをインストールする作業を行う際は、そのバージョンの公開日を確認し、**公開から 7 日未満のバージョンには極力更新しない**こと。Dependabot の `cooldown` は Dependabot 自身が作成する PR にしか効かず、エージェントが `npm install pkg@latest` 等で直接手動更新する操作は保護対象外のため、エージェント自身がこのルールを尊重する必要がある。
-  - ただし、既知の CVE（GitHub Security Advisory / Dependabot Alert で特定されたもの）を修正するための緊急パッチ適用はこの限りではなく、cooldown を待たず速やかに対応する。
-  - AI が生成したパッケージ名をそのままインストールしない（"slopsquatting" 対策）。パッケージ名は公式レジストリ（npmjs.com / nuget.org）で実在と提供元を必ず確認する。
+- **依存パッケージの更新は「公開から 7 日以上経過したバージョン」を原則とする**。サプライチェーン攻撃（乗っ取られたパッケージが公開直後に配布され、数時間〜数日で発覚・撤回されるケースが大半）への対策で、以下の設定で多重に担保している。
+  - `.github/dependabot.yml` の `cooldown`: Dependabot が作成するバージョン更新 PR に 7 日（メジャーは 14 日）の cooldown を適用（脆弱性対応PRは対象外、常に即時）。
+  - `pnpm-workspace.yaml` の `minimumReleaseAge: 10080`（分単位 = 7日）: pnpm CLI（≥10.16、本リポジトリの要求は `>=10.0.0`）が **`pnpm install`/`pnpm add` を実行する時点**でブロックする。開発者・CI・AI エージェントによる手動実行にも及ぶため、Dependabot の cooldown が保護できない「手動インストール」の穴を埋める。
+  - `.npmrc` の `min-release-age=7`: npm CLI（≥11.10.0）で `npm`/`npx` を直接使う場合の保険。
+  - **NuGet（.NET）にはこの種のネイティブ機能が現時点で存在しない**（[NuGet/Home#14657](https://github.com/NuGet/Home/issues/14657) で議論中・未実装）。そのため NuGet パッケージの追加・更新は下記のエージェント向け注意に従い、手動でのバージョン確認を徹底すること。
+  - ⚠️ **AI エージェント（Copilot coding agent / Copilot CLI 等）向け注意**:
+    - npm/pnpm パッケージについては上記の `minimumReleaseAge`/`min-release-age` 設定が `pnpm add`/`npm install` 実行時に自動的に古すぎないバージョンを拒否するため、通常操作でこれらのコマンドがエラーになった場合はバージョンを固定して待つか `pnpm add pkg@<7日以上前のバージョン>` のように明示指定し、**設定を緩めたり `minimumReleaseAgeExclude`/`min-release-age-exclude` で不用意に除外しない**こと。
+    - **NuGet パッケージは自動保護がないため要注意**: `dotnet add package` でバージョンを追加・更新する際は、公開日を nuget.org で確認し、公開から 7 日未満のバージョンには極力更新しないこと。
+    - 既知の CVE（GitHub Security Advisory / Dependabot Alert で特定されたもの）を修正するための緊急パッチ適用はこの限りではなく、cooldown を待たず速やかに対応する（必要なら `--min-release-age=0` 等で明示的にオーバーライドしてよい）。
+    - AI が生成したパッケージ名をそのままインストールしない（"slopsquatting" 対策）。パッケージ名は公式レジストリ（npmjs.com / nuget.org）で実在と提供元を必ず確認する。
 
 ## Pre-checkin Validation Steps
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
   # npm (フロントエンド + E2E)
+  # cooldown: サプライチェーン攻撃対策として、公開直後（乗っ取り・不正パッケージが
+  # 出回りやすい期間）のバージョンへは自動更新PRを出さず、公開から一定日数
+  # 経過したバージョンのみを対象とする。脆弱性対応PR（Security Update）には
+  # cooldown は適用されず、従来通り即時にPRが作成される。
   - package-ecosystem: "npm"
     directory: "/src/frontend"
     schedule:
@@ -14,6 +18,11 @@ updates:
       - "frontend"
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
 
   - package-ecosystem: "npm"
     directory: "/src/tests/e2e"
@@ -26,6 +35,11 @@ updates:
       - "e2e"
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
 
   # NuGet (.NET バックエンド)
   - package-ecosystem: "nuget"
@@ -39,8 +53,15 @@ updates:
       - "backend"
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
 
   # GitHub Actions ワークフロー
+  # GitHub Actions は SemVer 準拠が保証されないため semver-*-days は使わず、
+  # default-days のみで一律 7 日の cooldown をかける。
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -52,3 +73,5 @@ updates:
       - "ci"
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# サプライチェーン攻撃対策: npm/npx を直接使用する場合（pnpm 経由の依存解決は
+# pnpm-workspace.yaml の minimumReleaseAge で制御される）にも同様の cooldown を適用する。
+# 公開から7日未満のバージョンはインストールを拒否する（npm CLI >= 11.10.0 で有効）。
+min-release-age=7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,14 @@
 packages:
   - "src/frontend"
   - "src/tests/e2e"
+# サプライチェーン攻撃対策: 公開直後（乗っ取り・不正パッケージが出回りやすい期間）の
+# バージョンは pnpm install/add 実行時点でインストールをブロックする。
+# Dependabot の cooldown（.github/dependabot.yml）は自動PR作成のみを制御するため、
+# 開発者や AI エージェントによる手動の `pnpm add`/`pnpm install` を保護できない。
+# minimumReleaseAge はその隙間を埋め、CLI 実行そのものを制御する（単位: 分）。
+minimumReleaseAge: 10080 # 7日 = 60*24*7
+minimumReleaseAgeStrict: true
+minimumReleaseAgeIgnoreMissingTime: true
 allowBuilds:
   '@parcel/watcher': true
   esbuild: true


### PR DESCRIPTION
## 概要
#325 対応。公開直後の乗っ取り／不正パッケージ配布によるサプライチェーン攻撃を軽減するため、以下の2層で「公開から一定日数（原則7日）経過したバージョンのみ更新する」仕組みを導入する。

1. **Dependabot の自動更新PR** に対する cooldown（`.github/dependabot.yml`）
2. **pnpm/npm CLI 自体**に対する minimumReleaseAge（`pnpm-workspace.yaml` / `.npmrc`）— 開発者・CI・AIエージェントによる手動の `pnpm add` / `npm install` も含めて実行時点でブロックする、Dependabotのcooldownでは保護できない領域

## 変更内容

### 1. `.github/dependabot.yml`（Dependabot自動PRの制御）
- npm（frontend / e2e）、NuGet（backend）: `cooldown.default-days: 7` / `semver-major-days: 14` / `semver-minor-days: 7` / `semver-patch-days: 7`
- GitHub Actions: `cooldown.default-days: 7`（SemVer準拠が保証されないため `semver-*-days` は未使用）
- **脆弱性対応PR（Security Update）には cooldown は適用されない**（Dependabotの仕様上、常に即時作成）。

### 2. `pnpm-workspace.yaml` / `.npmrc`（CLI実行そのものの制御・追加調査により判明）
- `minimumReleaseAge: 10080`（分単位=7日）+ `minimumReleaseAgeStrict: true` + `minimumReleaseAgeIgnoreMissingTime: true` を追加。pnpm v10.16以降がネイティブ対応する機能で、本リポジトリの `pnpm@11.17.0` で有効。`pnpm install --frozen-lockfile` で `Lockfile passes supply-chain policies` と表示されることを確認済み。
- `.npmrc` に `min-release-age=7` を追加（npm CLI v11.10.0以降の同等機能。直接 npm/npx を使う場面の保険）。
- **これらはDependabotとは独立して機能し、開発者やAIエージェントが手動でパッケージを追加・更新する操作にも適用される**点が、Dependabot cooldownとの決定的な違い。

### 3. `.github/copilot-instructions.md`（AIエージェント向け注意事項）
- npm/pnpmは上記のネイティブ設定で保護されるため、エージェントはこれらの設定を安易に緩めたり除外リストに追加したりしないこと、を明記。
- **NuGet（.NET）にはこの種のネイティブ機能が現時点で存在しない**（[NuGet/Home#14657](https://github.com/NuGet/Home/issues/14657) で議論中・未実装）ため、NuGetパッケージの追加・更新時は公開日をnuget.orgで確認し、7日未満のバージョンは避けるようエージェント向けに明記。
- 既知CVE対応の緊急パッチ適用は cooldown の限りではないことも明記。
- AI生成のパッケージ名をそのまま信用しない（slopsquatting対策）ことも明記。

## 調査サマリー（/research 実施・2回）

**1回目（Dependabot cooldown）:**
- GitHub Dependabot は 2025年7月に `cooldown` オプションをGA、2026年7月からは未設定でも3日間のcooldownがデフォルト適用されるようになった。本PRはさらに厳格化し最低7日（メジャー更新は14日）とする。
- cooldownは「バージョン更新PR」にのみ適用され、脆弱性対応PRには適用されない。

**2回目（npm/pnpm/NuGetのネイティブ機能）:**
- **pnpm**: v10.16（2025年9月）で `minimumReleaseAge` をネイティブサポート、v11からはデフォルトで24時間(1440分)が有効。単位は分、`minimumReleaseAgeExclude`で個別除外可能。
- **npm**: v11.10.0（2026年2月）で `min-release-age`（単位: 日）をネイティブサポート。`.npmrc`で設定。
- **NuGet**: ネイティブ機能なし。[NuGet/Home#14657](https://github.com/NuGet/Home/issues/14657)で議論中も未実装。回避策はJFrog/Sonatypeのようなレジストリプロキシ、またはコミュニティ製`dotnet-pkg-age`をCIで実行する方法のみ。
- これらCLIネイティブの設定は、Dependabotの自動PRだけでなく**人間・CI・AIエージェントによる手動インストールも含めて実行時点でブロックする**ため、Dependabot cooldownを補完する重要な追加防御層となる。

## 検証
- `pnpm install --frozen-lockfile` を実行し、`Lockfile passes supply-chain policies (1346 entries)` の出力で設定が正しく認識されることを確認。
- YAML構文を目視確認。

Closes #325