### PR TITLE
feat(frontend): migrate legacy SEARCH_KEYWORDS to idb-keyval store

### DIFF
--- a/src/frontend/src/app/features/upcoming-filter.store.spec.ts
+++ b/src/frontend/src/app/features/upcoming-filter.store.spec.ts
@@ -181,4 +181,156 @@ describe('UpcomingFilterStore', () => {
     expect(store.restored()).toBe(true);
     expect(getMock).not.toHaveBeenCalled();
   });
+
+  describe('legacy SEARCH_KEYWORDS migration', () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('migrates legacy keywords into empty IndexedDB store and removes legacy data', async () => {
+      localStorage.setItem(
+        'SEARCH_KEYWORDS',
+        JSON.stringify(['紅殻のパンドラ', '幼女戦記', '月刊少女']),
+      );
+      getMock.mockResolvedValue(undefined);
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual(['紅殻のパンドラ', '幼女戦記', '月刊少女']);
+      expect(setMock).toHaveBeenCalledWith('upcoming-filter-keywords', [
+        '紅殻のパンドラ',
+        '幼女戦記',
+        '月刊少女',
+      ]);
+      expect(localStorage.getItem('SEARCH_KEYWORDS')).toBeNull();
+    });
+
+    it('merges legacy keywords with existing IndexedDB keywords (new store first, dedup)', async () => {
+      localStorage.setItem('SEARCH_KEYWORDS', JSON.stringify(['幼女戦記', 'ベルセルク']));
+      getMock.mockResolvedValue(['紅殻のパンドラ', 'ベルセルク']);
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual(['紅殻のパンドラ', 'ベルセルク', '幼女戦記']);
+      expect(setMock).toHaveBeenCalledWith('upcoming-filter-keywords', [
+        '紅殻のパンドラ',
+        'ベルセルク',
+        '幼女戦記',
+      ]);
+      expect(localStorage.getItem('SEARCH_KEYWORDS')).toBeNull();
+    });
+
+    it('discards malformed JSON and removes the legacy key', async () => {
+      localStorage.setItem('SEARCH_KEYWORDS', '{not-json');
+      getMock.mockResolvedValue(['既存']);
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual(['既存']);
+      expect(setMock).not.toHaveBeenCalled();
+      expect(localStorage.getItem('SEARCH_KEYWORDS')).toBeNull();
+    });
+
+    it('discards non-array legacy payloads and removes the legacy key', async () => {
+      localStorage.setItem('SEARCH_KEYWORDS', JSON.stringify({ keywords: ['x'] }));
+      getMock.mockResolvedValue(['既存']);
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual(['既存']);
+      expect(setMock).not.toHaveBeenCalled();
+      expect(localStorage.getItem('SEARCH_KEYWORDS')).toBeNull();
+    });
+
+    it('does nothing when the legacy key is absent', async () => {
+      getMock.mockResolvedValue(['既存']);
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual(['既存']);
+      expect(setMock).not.toHaveBeenCalled();
+    });
+
+    it('caps merged keywords at MAX_KEYWORDS (16), new-store first', async () => {
+      const existing = Array.from({ length: 14 }, (_, i) => `既存${i}`);
+      const legacy = Array.from({ length: 5 }, (_, i) => `旧${i}`);
+      localStorage.setItem('SEARCH_KEYWORDS', JSON.stringify(legacy));
+      getMock.mockResolvedValue(existing);
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual([...existing, '旧0', '旧1']);
+      expect(store.keywords()).toHaveLength(16);
+      expect(localStorage.getItem('SEARCH_KEYWORDS')).toBeNull();
+    });
+
+    it('caps merged keywords at MAX_KEYWORD_CHARACTERS (512)', async () => {
+      const existing = ['a'.repeat(500)];
+      const legacy = ['b'.repeat(20), 'c'.repeat(5)];
+      localStorage.setItem('SEARCH_KEYWORDS', JSON.stringify(legacy));
+      getMock.mockResolvedValue(existing);
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual([existing[0], 'c'.repeat(5)]);
+    });
+
+    it('skips migration during SSR (no localStorage access)', async () => {
+      localStorage.setItem('SEARCH_KEYWORDS', JSON.stringify(['幼女戦記']));
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [{ provide: PLATFORM_ID, useValue: 'server' }],
+      });
+      store = TestBed.inject(UpcomingFilterStore);
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual([]);
+      expect(setMock).not.toHaveBeenCalled();
+      expect(localStorage.getItem('SEARCH_KEYWORDS')).toBe(JSON.stringify(['幼女戦記']));
+    });
+
+    it('recovers when localStorage.getItem throws', async () => {
+      const spy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new DOMException('denied', 'SecurityError');
+      });
+      getMock.mockResolvedValue(['既存']);
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual(['既存']);
+      expect(setMock).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('normalizes and dedups legacy keywords via NFKC/trim', async () => {
+      localStorage.setItem(
+        'SEARCH_KEYWORDS',
+        JSON.stringify([' 幼女戦記 ', 'ＡＢＣ', 'ABC', '', 42]),
+      );
+      getMock.mockResolvedValue(undefined);
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual(['幼女戦記', 'ABC']);
+      expect(localStorage.getItem('SEARCH_KEYWORDS')).toBeNull();
+    });
+
+    it('retains the legacy key when IndexedDB set() fails so migration retries next boot', async () => {
+      const legacy = JSON.stringify(['幼女戦記', 'ベルセルク']);
+      localStorage.setItem('SEARCH_KEYWORDS', legacy);
+      getMock.mockResolvedValue(undefined);
+      setMock.mockRejectedValueOnce(new Error('idb write failed'));
+
+      await store.restore();
+
+      expect(store.keywords()).toEqual(['幼女戦記', 'ベルセルク']);
+      expect(localStorage.getItem('SEARCH_KEYWORDS')).toBe(legacy);
+    });
+  });
 });

--- a/src/frontend/src/app/features/upcoming-filter.store.ts
+++ b/src/frontend/src/app/features/upcoming-filter.store.ts
@@ -3,6 +3,7 @@ import { Injectable, inject, PLATFORM_ID, signal } from '@angular/core';
 import { del, get, set } from 'idb-keyval';
 
 const STORAGE_KEY = 'upcoming-filter-keywords';
+const LEGACY_STORAGE_KEY = 'SEARCH_KEYWORDS';
 export const MAX_KEYWORDS = 16;
 export const MAX_KEYWORD_CHARACTERS = 512;
 
@@ -96,12 +97,64 @@ export class UpcomingFilterStore {
 
     try {
       const saved = await get<unknown>(STORAGE_KEY);
-      this.keywords.set(normalizeKeywords(saved));
+      const current = normalizeKeywords(saved);
+      const migrated = await this.migrateLegacyKeywords(current);
+      this.keywords.set(migrated);
     } catch {
       this.keywords.set([]);
     } finally {
       this.restored.set(true);
     }
+  }
+
+  private async migrateLegacyKeywords(current: readonly string[]): Promise<readonly string[]> {
+    let raw: string | null;
+    try {
+      raw = localStorage.getItem(LEGACY_STORAGE_KEY);
+    } catch {
+      return current;
+    }
+
+    if (raw === null) return current;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      safeRemoveLegacy();
+      return current;
+    }
+
+    if (!Array.isArray(parsed)) {
+      safeRemoveLegacy();
+      return current;
+    }
+
+    const merged: string[] = [...current];
+    for (const item of parsed) {
+      if (typeof item !== 'string') continue;
+      const keyword = normalizeKeyword(item);
+      if (!keyword || merged.includes(keyword)) continue;
+      const next = [...merged, keyword];
+      if (!isWithinKeywordLimit(next) || !isWithinCharacterLimit(next)) continue;
+      merged.push(keyword);
+    }
+
+    if (merged.length === current.length) {
+      // Nothing new to persist (all legacy entries were duplicates, invalid, or over the limit).
+      safeRemoveLegacy();
+      return merged;
+    }
+
+    try {
+      await set(STORAGE_KEY, merged);
+    } catch {
+      // Keep the legacy key so migration is retried on the next boot.
+      return merged;
+    }
+
+    safeRemoveLegacy();
+    return merged;
   }
 
   private async commit(keywords: readonly string[]): Promise<void> {
@@ -156,4 +209,12 @@ function isWithinKeywordLimit(keywords: readonly string[]): boolean {
 
 function isWithinCharacterLimit(keywords: readonly string[]): boolean {
   return keywords.reduce((total, keyword) => total + keyword.length, 0) <= MAX_KEYWORD_CHARACTERS;
+}
+
+function safeRemoveLegacy(): void {
+  try {
+    localStorage.removeItem(LEGACY_STORAGE_KEY);
+  } catch {
+    // ignore storage access errors (private mode, quota, etc.)
+  }
 }


### PR DESCRIPTION
## Summary
Adds a one-shot migration in `UpcomingFilterStore.restore()` that moves the pre-#210 `localStorage['SEARCH_KEYWORDS']` payload (旧 `src/front/` の AngularFire 時代フォーマット、例: `["紅殻のパンドラ","幼女戦記",...]`) into the new `idb-keyval['upcoming-filter-keywords']` store, so users upgrading do not lose their filter keywords.

## Behavior
- **Merge strategy**: 新形式 (idb-keyval) を先頭に、旧データを続けて追加。NFKC 正規化 + trim + 重複除外 + `MAX_KEYWORDS (16)` / `MAX_KEYWORD_CHARACTERS (512)` 上限内。
- **Idempotent**: 移行成功時のみ `localStorage.removeItem('SEARCH_KEYWORDS')` を実行。`set()` 失敗時は旧キーを残し次回起動でリトライ。
- **Defensive**: SSR / `localStorage` 例外 / `JSON.parse` 失敗 / 非配列ペイロード / `set()` 失敗すべてを握りつぶし、`restored` が `true` にならないパスを排除。

## Files
- `src/frontend/src/app/features/upcoming-filter.store.ts` — new `migrateLegacyKeywords()` + `safeRemoveLegacy()` helper invoked from `restoreKeywords()`
- `src/frontend/src/app/features/upcoming-filter.store.spec.ts` — 11 new Jest cases covering happy path, merge/dedup, upper limits, malformed JSON, non-array payload, SSR, `localStorage` throw, and `set()` write failure retry semantics

## Review
- Fleet モードで開発、RubberDuck エージェントによる review 済み。RubberDuck が指摘した「`set()` 失敗時に旧キーが削除済みで再試行できない」バグを修正し、対応するテストを追加。

## Verification
- `pnpm --filter frontend test` → 23/23 pass (12 既存 + 11 新規)
- `pnpm --filter frontend lint` → clean

Closes #323