### PR TITLE
chore(security): extend dependabot ecosystem coverage to root npm, backend tests nuget, and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,25 @@
 version: 2
 updates:
+  # npm (ルート開発ツール)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "root"
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+
   # npm (フロントエンド + E2E)
   # cooldown: サプライチェーン攻撃対策として、公開直後（乗っ取り・不正パッケージが
   # 出回りやすい期間）のバージョンへは自動更新PRを出さず、公開から一定日数
@@ -58,6 +78,43 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 7
+
+  # NuGet (.NET バックエンドテスト)
+  - package-ecosystem: "nuget"
+    directory: "/src/tests/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "backend-test"
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+
+  # Docker イメージ
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
 
   # GitHub Actions ワークフロー
   # GitHub Actions は SemVer 準拠が保証されないため semver-*-days は使わず、


### PR DESCRIPTION
## Summary
- Extend Dependabot coverage for RubberDuck workstream W-DEPA.
- Plan reference: /home/vscode/.copilot/session-state/d7a972e4-dea8-4444-a663-3f5438e8d818/plan.md (W-DEPA)

## Checklist
- [x] Add root npm Dependabot entry for `/`
- [x] Add backend tests NuGet Dependabot entry for `/src/tests/backend`
- [x] Add Docker Dependabot entry for root `docker-compose.yml`

## Validation
- [x] `pnpm exec prettier --check .github/dependabot.yml`