### PR TITLE
chore(security): document Scorecard governance decisions (#10,#17,#18,#19,#20,#22)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # セキュリティポリシー
 
+Last updated: 2026-08-01
+
 ## サポートバージョン
 
 | バージョン | サポート状況 |
@@ -10,8 +12,10 @@
 
 脆弱性を発見した場合は、**公開 Issue を作成せず**、以下のいずれかの方法でご連絡ください。
 
-1. **GitHub Security Advisory**: このリポジトリの Security タブ → "Report a vulnerability" から報告してください。
+1. **GitHub Security Advisory**: [Report a vulnerability](https://github.com/Takas0522/ComiCal/security/advisories/new) から非公開で報告してください。
 2. **メール**: リポジトリオーナーに直接ご連絡ください。
+
+> **Note**: GitHub の Private vulnerability reporting はリポジトリ Settings で有効化済みです。報告内容は修正と公開開示の準備が整うまで非公開で取り扱います。
 
 ## 対応ポリシー
 

--- a/docs/adr/0002-branch-protection-ruleset.md
+++ b/docs/adr/0002-branch-protection-ruleset.md
@@ -1,0 +1,146 @@
+# 0002. Branch Protection Ruleset for main
+
+- **Status**: Accepted
+- **Date**: 2026-08-01
+- **Deciders**: Repository maintainer, Copilot coding agent
+
+## Context and Problem Statement
+
+OpenSSF Scorecard reports governance alerts for Branch-Protection (#10) and Code-Review (#17). The repository follows trunk-based development and requires PR-based changes, but the policy must be represented as an enforceable GitHub Ruleset so direct pushes and unreviewed merges cannot silently bypass the documented process.
+
+ComiCal is currently a single-maintainer repository. The maintainer needs an auditable emergency bypass for repository recovery, security hotfixes, and misconfigured CI/ruleset remediation; therefore the ruleset allows repository administrators to bypass with an audit trail.
+
+SAST (#22) was also investigated while defining the required checks. CodeQL is enabled in `.github/workflows/codeql.yml` for `push` to `main`, `pull_request` to `main`, and a weekly Monday 03:00 UTC schedule. `gh run list --workflow=codeql.yml -L 30` showed recent `main` pushes on 2026-08-01 completed successfully. The Scorecard alert text says “25 commits out of 27 are checked with a SAST tool”; comparing the current latest 27 `main` commits with `/code-scanning/analyses?tool_name=CodeQL` found all 27 now have CodeQL analyses. Older missing analyses are historical 2026-05-02 dependency/workflow commits from before the current CodeQL coverage was consistently uploaded. No trigger or `paths-ignore` gap was found, so no workflow change is made in this ADR.
+
+## Decision Drivers
+
+- Enforce PR-only changes to `main` and prevent direct push/force-push drift.
+- Require at least one approving review for Scorecard Code-Review expectations while preserving single-maintainer recovery.
+- Require CI, infrastructure validation, and CodeQL/SAST before merging.
+- Keep merge history linear and align the final `main` commit with Conventional Commits via squash merge.
+- Make the maintainer-only administrative action reproducible because this agent lacks GitHub admin API access.
+
+## Considered Options
+
+- **Option A: Repository Ruleset on `main` with admin bypass** — Require PRs, one approval, status checks, CodeQL/code scanning, linear history, and squash-only PR merge method; allow repository admins to bypass when necessary.
+- **Option B: Legacy branch protection rule** — Use classic branch protection for reviews and status checks.
+- **Option C (Status quo)** — Keep the written branching policy without GitHub enforcement.
+
+## Decision Outcome
+
+採用案: **Option A: Repository Ruleset on `main` with admin bypass**
+
+### Rationale
+
+GitHub Rulesets are the current policy-as-configuration mechanism and can cover pull request requirements, required checks, non-fast-forward protection, linear history, CodeQL code scanning, and bypass actors in one auditable object. Admin bypass is intentionally limited to repository administrators (`RepositoryRole` actor id `5`) because the repository has a single maintainer and must remain recoverable if a required check or ruleset is misconfigured.
+
+### Required policy
+
+- PR-only for `refs/heads/main`; no direct push to `main` for non-bypass actors.
+- One approving review before merge.
+- Stale approvals are dismissed on new reviewable pushes.
+- Review conversations must be resolved.
+- Force pushes are blocked.
+- Linear history is required.
+- Allowed pull request merge method is squash only.
+- Required logical checks: `lint`, `test-frontend`, `test-backend`, `build-db`, `bicep-what-if`, and `codeql`.
+- CodeQL code scanning must report results with no `errors` and no `high_or_higher` security alerts before `main` is updated.
+- Repository administrators may bypass for emergency recovery and single-maintainer continuity; bypasses must be noted in the PR/issue timeline.
+
+### Maintainer command
+
+This agent cannot apply repository rulesets because it does not have GitHub admin API access. The maintainer must run the following from an authenticated `gh` session with admin access. If the ruleset does not exist yet, create an empty `main-protection` ruleset in the UI or by changing `--method PUT /repos/Takas0522/ComiCal/rulesets/${RULESET_ID}` to `--method POST /repos/Takas0522/ComiCal/rulesets` and removing the `RULESET_ID` lookup.
+
+```bash
+RULESET_ID=$(gh api /repos/Takas0522/ComiCal/rulesets \
+  --jq '.[] | select(.name == "main-protection") | .id')
+
+gh api --method PUT "/repos/Takas0522/ComiCal/rulesets/${RULESET_ID}" \
+  -H 'Accept: application/vnd.github+json' \
+  -H 'X-GitHub-Api-Version: 2026-03-10' \
+  --input - <<'JSON'
+{
+  "name": "main-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": ["squash"],
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    },
+    { "type": "required_linear_history" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "required_status_checks": [
+          { "context": "lint" },
+          { "context": "test-frontend" },
+          { "context": "test-backend" },
+          { "context": "build-db" },
+          { "context": "bicep-what-if" },
+          { "context": "codeql" }
+        ]
+      }
+    },
+    {
+      "type": "code_scanning",
+      "parameters": {
+        "code_scanning_tools": [
+          {
+            "tool": "CodeQL",
+            "alerts_threshold": "errors",
+            "security_alerts_threshold": "high_or_higher"
+          }
+        ]
+      }
+    }
+  ]
+}
+JSON
+```
+
+Because GitHub required status check names must match exact check-run contexts, the maintainer should verify the check names after the next PR run. If current workflows expose different context labels, either rename/add aggregate jobs to `lint`, `test-frontend`, `test-backend`, `build-db`, `bicep-what-if`, and `codeql`, or update the ruleset contexts to the observed names before setting `enforcement` to `active`.
+
+### Consequences
+
+- ✅ Positive: Scorecard Branch-Protection and Code-Review expectations become enforceable, auditable repository settings.
+- ✅ Positive: Required checks and CodeQL are explicit merge gates for `main`.
+- ⚠️ Negative / Trade-off: Admin bypass can reduce strictness, but is documented and limited to repository administrators for single-maintainer recovery.
+- ⚠️ Negative / Trade-off: Incorrect status check context names can block all PR merges; verification is required before or immediately after activation.
+
+## Validation
+
+- Run `gh api /repos/Takas0522/ComiCal/rulesets --jq '.[] | select(.name == "main-protection")'` and confirm `enforcement` is `active`.
+- Run `gh api /repos/Takas0522/ComiCal/rules/branches/main --jq '.[].type'` and confirm `pull_request`, `required_status_checks`, `required_linear_history`, `non_fast_forward`, and `code_scanning` apply to `main`.
+- Open a test PR and confirm direct push is blocked, one approval is required, and required checks gate merging.
+- Re-run OpenSSF Scorecard after ruleset activation and confirm alerts #10 and #17 close or are dismissible with this ADR.
+- Re-run CodeQL or wait for the weekly schedule and confirm SAST alert #22 no longer reports unchecked recent commits.
+
+## Links
+
+- OpenSSF Scorecard Branch-Protection alert: https://github.com/Takas0522/ComiCal/security/code-scanning/10
+- OpenSSF Scorecard Code-Review alert: https://github.com/Takas0522/ComiCal/security/code-scanning/17
+- OpenSSF Scorecard SAST alert: https://github.com/Takas0522/ComiCal/security/code-scanning/22
+- GitHub Rulesets REST API: https://docs.github.com/en/rest/repos/rules

--- a/docs/adr/0003-security-scope-decisions.md
+++ b/docs/adr/0003-security-scope-decisions.md
@@ -1,0 +1,69 @@
+# 0003. Security Scope Decisions for Fuzzing and CII Best Practices
+
+- **Status**: Accepted
+- **Date**: 2026-08-01
+- **Deciders**: Repository maintainer, Copilot coding agent
+
+## Context and Problem Statement
+
+OpenSSF Scorecard reports governance alerts for Fuzzing (#20) and CII-Best-Practices (#19). ComiCal is a web application that aggregates manga release information from Rakuten Books API and exposes bounded user workflows such as search, subscriptions, and purchase tracking. It is not a reusable parser, compiler, protocol implementation, cryptography library, or native memory component that would naturally fit OSS-Fuzz onboarding.
+
+The CII Best Practices badge is useful for public security posture, but it is a self-enrollment and evidence collection process outside the code changes required for this workstream. It should be tracked explicitly without blocking the governance documentation PR.
+
+## Decision Drivers
+
+- Focus security engineering effort on the highest-risk input surfaces for this application.
+- Avoid introducing an OSS-Fuzz integration that would have low signal and high maintenance cost for a bounded web app.
+- Keep Scorecard dismissals auditable by documenting rationale and residual risk.
+- Track the CII badge as a separate maintainer-owned governance task.
+
+## Considered Options
+
+- **Option A: Risk-accept fuzzing for now and track CII badge separately** — Use existing xUnit boundary tests and Testcontainers-backed integration tests for the bounded input surface; open a follow-up issue for CII badge enrollment.
+- **Option B: Add OSS-Fuzz immediately** — Attempt to build fuzz harnesses and OSS-Fuzz project configuration in this PR.
+- **Option C (Status quo)** — Leave both Scorecard alerts open without documented rationale or follow-up.
+
+## Decision Outcome
+
+採用案: **Option A: Risk-accept fuzzing for now and track CII badge separately**
+
+### Rationale
+
+ComiCal's main untrusted inputs are HTTP API request bodies, authentication claims from Entra External ID, and Rakuten Books API JSON responses. These are better protected by validators, schema/contract tests, boundary tests, and integration tests than by OSS-Fuzz-style native fuzz harnesses. OSS-Fuzz remains out of scope until the repository introduces a parser/protocol component or a high-risk transformation layer with a stable fuzz target.
+
+The CII Best Practices badge is not a code dependency or runtime control. It should be pursued as a separate governance checklist so the maintainer can provide accurate project metadata, policy evidence, and process attestations.
+
+### Scope decisions
+
+#### Fuzzing (#20)
+
+- Decision: Do not onboard OSS-Fuzz for this workstream.
+- Justification: The application is content-aggregation focused with limited untrusted input surface; existing .NET xUnit boundary tests and frontend/backend validation cover the relevant request/response boundaries.
+- Residual risk: Rakuten Books API JSON parsing or future feed transformations may accept malformed or unexpected data.
+- Mitigation: Keep schema/DTO validation and boundary tests around Rakuten API responses; add targeted property/fuzz-style tests if a new parser or complex normalizer is introduced.
+
+#### CII Best Practices (#19)
+
+- Decision: Do not block this PR on badge enrollment.
+- Justification: CII badge completion is self-enrollment requiring maintainer verification of project practices and public metadata.
+- Follow-up: Track issue #337 for the maintainer to complete the badge questionnaire and attach evidence.
+
+### Consequences
+
+- ✅ Positive: Governance risk acceptance is explicit and reviewable instead of being an unexplained Scorecard dismissal.
+- ✅ Positive: Testing investment remains aligned with the actual web application input surface.
+- ⚠️ Negative / Trade-off: Scorecard Fuzzing remains a risk-accepted/dismissal item rather than a technical implementation.
+- ⚠️ Negative / Trade-off: CII badge score improvement is deferred until maintainer self-enrollment is complete.
+
+## Validation
+
+- Confirm this ADR is linked when dismissing Scorecard Fuzzing alert #20 as `tolerable_risk` or equivalent maintainer-approved rationale.
+- Confirm the follow-up CII badge issue exists and is linked from alert #19 before dismissing or resolving the alert.
+- During future parser/feed-normalization changes, require tests for malformed Rakuten API JSON and reconsider property-based or fuzz-style tests.
+
+## Links
+
+- OpenSSF Scorecard Fuzzing alert: https://github.com/Takas0522/ComiCal/security/code-scanning/20
+- OpenSSF Scorecard CII-Best-Practices alert: https://github.com/Takas0522/ComiCal/security/code-scanning/19
+- Follow-up CII badge issue: https://github.com/Takas0522/ComiCal/issues/337
+- CII Best Practices Badge: https://www.bestpractices.dev/


### PR DESCRIPTION
## Summary\n- Enrich SECURITY.md with direct private advisory URL, last-updated metadata, and private reporting note.\n- Add ADR-0002 documenting the main branch ruleset, admin bypass rationale, exact maintainer gh api command, and SAST investigation.\n- Add ADR-0003 documenting Fuzzing/CII scope decisions and link follow-up issue #337.\n\n## SAST investigation\n- CodeQL workflow already runs on push to main, pull_request to main, and weekly schedule.\n- gh run list showed recent 2026-08-01 main pushes completed CodeQL successfully.\n- Alert #22 says 25/27 commits were checked; current comparison of latest 27 main commits against CodeQL analyses found all 27 now covered. Older missing analyses are historical 2026-05-02 commits before current consistent CodeQL uploads. No workflow trigger or paths-ignore gap found, so no CI change in this PR.\n\n## Deferred to maintainer\n- Apply the documented GitHub Ruleset with admin access.\n- Review/dismiss Scorecard alerts after ADR review; this PR does not dismiss alerts.\n- Complete CII Best Practices badge follow-up in #337.\n\n## Validation\n- git diff --check main...HEAD