### PR TITLE
fix(deps): bump @cyclonedx/cyclonedx-npm to ^5.0.0 (GHSA-v75r-vx73-82pj)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@angular-eslint/eslint-plugin": "^19.0.0",
-    "@cyclonedx/cyclonedx-npm": "^4.2.1",
+    "@cyclonedx/cyclonedx-npm": "^5.0.0",
     "@eslint/js": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^19.0.0
         version: 19.8.1(@typescript-eslint/utils@8.59.1(eslint@9.39.4(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)(supports-color@10.2.2))(typescript@6.0.3)
       '@cyclonedx/cyclonedx-npm':
-        specifier: ^4.2.1
-        version: 4.2.1
+        specifier: ^5.0.0
+        version: 5.0.0
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.39.4
@@ -1214,8 +1214,8 @@ packages:
       xmlbuilder2:
         optional: true
 
-  '@cyclonedx/cyclonedx-npm@4.2.1':
-    resolution: {integrity: sha512-SOA/96sf0wsgUYCRtFkLFm6WoFhG+q1BxdC84hPSn9J3xWlH1e7OnTPJT+WNUzTqzX1nSm5JhjRX4krozu2X+g==}
+  '@cyclonedx/cyclonedx-npm@5.0.0':
+    resolution: {integrity: sha512-pEz/pqYJHQ0ZvY5xFJa+GQ5AjNL7JOEJCXCHymvKo2N1VnzKE1ROpkumduJt8a0DukQjQfBGRXouGQ9xqJtJaQ==}
     engines: {node: '>=20.18.0', npm: '>=9'}
     hasBin: true
 
@@ -7915,7 +7915,7 @@ snapshots:
       spdx-expression-parse: 4.0.0
       xmlbuilder2: 3.1.1
 
-  '@cyclonedx/cyclonedx-npm@4.2.1':
+  '@cyclonedx/cyclonedx-npm@5.0.0':
     dependencies:
       '@cyclonedx/cyclonedx-library': 10.0.0(ajv-formats-draft2019@1.6.1(ajv@8.20.0))(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)(packageurl-js@2.0.1)(spdx-expression-parse@4.0.0)(xmlbuilder2@3.1.1)
       commander: 14.0.3
@@ -8797,7 +8797,7 @@ snapshots:
 
   '@npmcli/fs@5.0.0':
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   '@npmcli/git@7.0.2':
     dependencies:
@@ -11814,7 +11814,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   make-error@1.3.6: {}
 
@@ -12034,7 +12034,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       tar: 7.5.13
       tinyglobby: 0.2.16
       undici: 6.25.0
@@ -12051,7 +12051,7 @@ snapshots:
   normalize-package-data@7.0.1:
     dependencies:
       hosted-git-info: 8.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   normalize-path@3.0.0: {}
@@ -12062,7 +12062,7 @@ snapshots:
 
   npm-install-checks@8.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   npm-normalize-package-bin@5.0.0: {}
 


### PR DESCRIPTION
## Summary
- Bumps root devDependency `@cyclonedx/cyclonedx-npm` from `^4.2.1` to `^5.0.0` for GHSA-v75r-vx73-82pj (shell injection), closing Dependabot alerts #331 and #330 after merge.
- Updates `pnpm-lock.yaml` with the v5 resolution.

## Pre-check findings
- `grep -r cyclonedx-npm tools/ docs/ .github/` found only `docs/specs/oo-init/19-oss-legal.md`, which describes a future/desired CI SBOM generator.
- No current `tools/` script or `.github/` workflow invokes `cyclonedx-npm`, so no caller update was needed.
- Since there is no real current usage, removal of this devDependency is a reasonable follow-up alternative, but this PR ships the safer security bump.

## Breaking-change notes
- v5.0.0 release notes: npm handling was reworked so `npm` is executed explicitly rather than through a subshell; `npm_execpath` behavior remains unchanged.
- Fix included: eliminates shell injection in `--workspace` (GHSA-v75r-vx73-82pj).
- Existing CLI flags used for the smoke test (`--ignore-npm-errors`, `--output-format`, `--output-file`) are still available. No repo workflow/script is affected because none currently calls this CLI.

## Validation
- `pnpm install --lockfile-only` passed without `minimumReleaseAge` override.
- `pnpm install` passed and installed `@cyclonedx/cyclonedx-npm 5.0.0`.
- SBOM smoke test command:
  ```bash
  pnpm exec cyclonedx-npm --ignore-npm-errors --output-format JSON --output-file sbom-test.json
  jq -c '{bomFormat,specVersion,componentsCount:(.components|length),metadataComponent:.metadata.component.name}' sbom-test.json
  ```
- SBOM output snippet:
  ```json
  {"bomFormat":"CycloneDX","specVersion":"1.6","componentsCount":2527,"metadataComponent":"comical"}
  ```

## Coordination
This PR touches `pnpm-lock.yaml` and must merge BEFORE W-TX. The W-TX branch should rebase after this lands.