### PR TITLE
chore(infra): reduce Azure cost by env-conditional SKUs

### DIFF
--- a/.github/workflows/dev-sql-nightly-pause.yml
+++ b/.github/workflows/dev-sql-nightly-pause.yml
@@ -1,0 +1,59 @@
+name: Dev SQL Nightly Pause
+
+# Cost optimization: force-pause the dev SQL Serverless database every night
+# so leftover connections from ad-hoc dev sessions cannot keep it warm and
+# accruing vCore-second charges. The autoPauseDelay (60 min minimum) still
+# applies during the day; this workflow just guarantees an overnight pause.
+
+on:
+  schedule:
+    # 14:00 UTC = 23:00 JST daily
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # Required for OIDC
+
+concurrency:
+  group: dev-sql-nightly-pause
+  cancel-in-progress: false
+
+jobs:
+  pause:
+    name: Pause dev SQL DB
+    runs-on: ubuntu-latest
+    env:
+      RG: cmcl-dev-jpe-rg
+      SERVER: cmcl-dev-jpe-sql
+      DB: cmcl-dev-jpe-sqldb
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Check current DB status
+        id: status
+        run: |
+          state=$(az sql db show -g "$RG" -s "$SERVER" -n "$DB" --query status -o tsv)
+          echo "Current state: $state"
+          echo "state=$state" >> "$GITHUB_OUTPUT"
+
+      - name: Pause DB if online
+        if: steps.status.outputs.state == 'Online'
+        run: |
+          echo "Pausing $DB ..."
+          az sql db pause -g "$RG" -s "$SERVER" -n "$DB"
+          echo "Pause requested."
+
+      - name: Skip (already paused)
+        if: steps.status.outputs.state != 'Online'
+        run: echo "DB is not Online (state=${{ steps.status.outputs.state }}); nothing to do."

--- a/infra/modules/app.bicep
+++ b/infra/modules/app.bicep
@@ -490,22 +490,27 @@ resource kvRoleAssignFuncBatch 'Microsoft.Authorization/roleAssignments@2022-04-
 // Static Web App (Standard) — hosts Angular SSR via Managed Functions
 // ──────────────────────────────────────────────────────────────────────────────
 
+// Cost optimization: Standard tier only in prod. Dev uses Free tier which lacks
+// linkedBackends, SystemAssigned Identity, custom auth, and SLA — acceptable for dev.
+var swaIsStandard = env == 'prod'
+
 resource swa 'Microsoft.Web/staticSites@2024-04-01' = {
   name: swaName
   location: swaLocation
   sku: {
-    name: 'Standard'
-    tier: 'Standard'
+    name: swaIsStandard ? 'Standard' : 'Free'
+    tier: swaIsStandard ? 'Standard' : 'Free'
   }
   identity: {
-    type: 'SystemAssigned'
+    type: swaIsStandard ? 'SystemAssigned' : 'None'
   }
   properties: {}
 }
 
 // Link the API Function App to the SWA so that /api/* requests are proxied
-// with the x-ms-client-principal header injected by SWA authentication
-resource swaLinkedBackend 'Microsoft.Web/staticSites/linkedBackends@2024-04-01' = {
+// with the x-ms-client-principal header injected by SWA authentication.
+// linkedBackends require the Standard tier, so only deploy for prod.
+resource swaLinkedBackend 'Microsoft.Web/staticSites/linkedBackends@2024-04-01' = if (swaIsStandard) {
   parent: swa
   name: 'apifunc'
   properties: {
@@ -514,7 +519,8 @@ resource swaLinkedBackend 'Microsoft.Web/staticSites/linkedBackends@2024-04-01' 
   }
 }
 
-resource kvRoleAssignSwa 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+// SWA Managed Identity → Key Vault Secrets User (only when SystemAssigned identity is available)
+resource kvRoleAssignSwa 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (swaIsStandard) {
   scope: kv
   name: guid(kv.id, swa.id, kvSecretsUserRoleId)
   properties: {
@@ -525,14 +531,15 @@ resource kvRoleAssignSwa 'Microsoft.Authorization/roleAssignments@2022-04-01' = 
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// App Configuration (Standard) — feature flags
+// App Configuration — Standard in prod, Free in dev (cost optimization)
+// Note: Free tier is limited to 1 store per subscription; keep prod on Standard.
 // ──────────────────────────────────────────────────────────────────────────────
 
 resource appConfig 'Microsoft.AppConfiguration/configurationStores@2023-03-01' = {
   name: appConfigName
   location: location
   sku: {
-    name: 'standard'
+    name: env == 'prod' ? 'standard' : 'free'
   }
   identity: {
     type: 'SystemAssigned'

--- a/infra/modules/observability.bicep
+++ b/infra/modules/observability.bicep
@@ -58,7 +58,8 @@ resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
 
 // Alert fires when the batch.failedItem custom metric total >= 5 within a 15-minute window.
 // The metric is emitted by the Batch Function App via Application Insights custom metrics.
-resource alertRule 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = {
+// Cost optimization: log alert rules are billed per rule per month, so deploy in prod only.
+resource alertRule 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (env == 'prod') {
   name: alertRuleName
   location: location
   properties: {


### PR DESCRIPTION
## 概要
Azure Cost Management API での実測に基づき、**dev 環境の SKU をダウングレード**してコスト削減。**prod は無変更**。

## 現状 (MTD)
| リソース | Dev | Prod | 備考 |
|---|--:|--:|---|
| App Configuration (Standard) | 4,130 | 4,130 | 固定日額課金 |
| SQL DB Serverless | 3,114 | 3,991 | auto-pause 60分 |
| Static Web App Standard | 1,014 | 1,014 | \/月 |
| Scheduled Query アラート | 165 | 165 | 1ルール \.50/月 |

## 変更内容
1. **App Configuration**: prod=Standard / dev=Free (~4,130 JPY/月 削減)
   - Free tier はサブスクリプションあたり 1 store のみのため prod は Standard 維持
2. **Static Web App**: prod=Standard / dev=Free (~1,014 JPY/月 削減)
   - Free tier では `linkedBackends` と SystemAssigned Identity 非対応のため関連 role assignment を prod 限定に
3. **Scheduled Query Alert (batch failed items)**: prod のみデプロイ (~165 JPY/月 削減)
4. **Dev SQL Nightly Pause Workflow** 追加: 毎日 23:00 JST に `az sql db pause` を実行し夜間に compute を確実に停止

## 削減見込み
**dev 環境で ~5,300 JPY/月** の削減 (prod は不変)

## Bicep 検証
- `az bicep build infra/main.bicep` → 成功 (既存 warning のみ)
- コンパイル後 ARM で SKU 条件式・`condition` プロパティが期待通りに出力されていることを確認済み

## 影響範囲
- prod 動作: 変更なし
- dev SWA: linkedBackend 経由の `/api/*` 呼び出しが使えなくなるため、開発時はローカル Functions か CORS 直呼びで動作確認
- dev の Batch 失敗アラート通知はなくなる (代替: App Insights の Failures ブレード目視)

## デプロイ手順
main へマージ → CD - Dev が Bicep を再適用し、既存の dev SWA / AppConfig / Alert が Free/削除に置き換わる