### PR TITLE
fix(rakuten): surface upstream 403 details in diagnostic log

### DIFF
--- a/src/backend/infrastructure/ComiCal.Infrastructure.Rakuten/RakutenBooksApiClient.cs
+++ b/src/backend/infrastructure/ComiCal.Infrastructure.Rakuten/RakutenBooksApiClient.cs
@@ -192,26 +192,77 @@ public sealed partial class RakutenBooksApiClient
         {
             using var document = JsonDocument.Parse(body);
             if (document.RootElement.ValueKind != JsonValueKind.Object)
-                return "Non-object JSON response.";
+                return BuildFallbackDiagnostic(body, response, "Non-object JSON response.");
 
-            foreach (var propertyName in new[] { "error", "error_description", "code", "message" })
+            if (TryExtractDiagnostic(document.RootElement, depth: 0, out var extracted))
             {
-                if (document.RootElement.TryGetProperty(propertyName, out var property) &&
-                    property.ValueKind == JsonValueKind.String)
-                {
-                    return property.GetString()!.ReplaceLineEndings(" ").Trim()[..Math.Min(
-                        property.GetString()!.ReplaceLineEndings(" ").Trim().Length,
-                        512)];
-                }
+                return Truncate(extracted!.ReplaceLineEndings(" ").Trim(), 512);
             }
 
-            return "JSON response without a recognized diagnostic field.";
+            // Rakuten sometimes returns 403 with an envelope that does not include the
+            // documented "error"/"error_description" fields (for example a Header/Body
+            // wrapper, or a plain rate-limit page). Fall back to a truncated raw body
+            // snapshot so the actual message reaches Application Insights.
+            return BuildFallbackDiagnostic(body, response, "JSON response without a recognized diagnostic field.");
         }
         catch (JsonException)
         {
-            return $"Non-JSON response ({response.Content.Headers.ContentType?.MediaType ?? "unknown content type"}).";
+            return BuildFallbackDiagnostic(
+                body,
+                response,
+                $"Non-JSON response ({response.Content.Headers.ContentType?.MediaType ?? "unknown content type"}).");
         }
     }
+
+    // Recursively look for common error-descriptor fields. Rakuten's non-2xx responses
+    // occasionally nest the diagnostic inside a wrapper object such as { "Header": {...},
+    // "Body": { "error": "wrong_parameter", "error_description": "..." } }.
+    private static bool TryExtractDiagnostic(JsonElement element, int depth, out string? value)
+    {
+        value = null;
+        if (depth > 3 || element.ValueKind != JsonValueKind.Object)
+            return false;
+
+        foreach (var propertyName in new[] { "error_description", "error", "message", "code" })
+        {
+            if (element.TryGetProperty(propertyName, out var property) &&
+                property.ValueKind == JsonValueKind.String)
+            {
+                var text = property.GetString();
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    value = text;
+                    return true;
+                }
+            }
+        }
+
+        foreach (var child in element.EnumerateObject())
+        {
+            if (child.Value.ValueKind == JsonValueKind.Object &&
+                TryExtractDiagnostic(child.Value, depth + 1, out value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Emit a short prefix of the raw response body so operators can see what the
+    // upstream actually returned. The body does not contain client credentials
+    // (those are only in the outbound URL and are never included here).
+    private static string BuildFallbackDiagnostic(string body, HttpResponseMessage response, string reason)
+    {
+        var mediaType = response.Content.Headers.ContentType?.MediaType ?? "unknown";
+        var trimmed = string.IsNullOrEmpty(body)
+            ? "(empty body)"
+            : Truncate(body.ReplaceLineEndings(" ").Trim(), 256);
+        return $"{reason} contentType={mediaType} bodyPrefix={trimmed}";
+    }
+
+    private static string Truncate(string value, int max)
+        => value.Length <= max ? value : value[..max];
 
     [LoggerMessage(
         Level = LogLevel.Warning,

--- a/src/backend/infrastructure/ComiCal.Infrastructure.Rakuten/RakutenBooksApiClient.cs
+++ b/src/backend/infrastructure/ComiCal.Infrastructure.Rakuten/RakutenBooksApiClient.cs
@@ -223,7 +223,7 @@ public sealed partial class RakutenBooksApiClient
         if (depth > 3 || element.ValueKind != JsonValueKind.Object)
             return false;
 
-        foreach (var propertyName in new[] { "error_description", "error", "message", "code" })
+        foreach (var propertyName in new[] { "error_description", "errorMessage", "error", "message", "errorCode", "code" })
         {
             if (element.TryGetProperty(propertyName, out var property) &&
                 property.ValueKind == JsonValueKind.String)

--- a/src/tests/backend/ComiCal.Batch.Tests/Activities/RakutenBooksApiClientTests.cs
+++ b/src/tests/backend/ComiCal.Batch.Tests/Activities/RakutenBooksApiClientTests.cs
@@ -117,6 +117,28 @@ public sealed class RakutenBooksApiClientTests
         Assert.Contains(sink, entry => entry.Contains("Access denied by upstream firewall", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task SearchComicsAsync_WhenRakutenReturnsRakutenErrorEnvelope_ExtractsErrorMessage()
+    {
+        // Actual production 403 payload observed on 2026-08-15 through 2026-08-21:
+        // {"errors":{"errorCode":403,"errorMessage":"CLIENT_IP_NOT_ALLOWED"}}
+        using var rateLimiter = CreateRateLimiter();
+        var (logger, sink) = CreateCapturingLogger();
+        using var client = new HttpClient(new StaticResponseHandler(
+            HttpStatusCode.Forbidden,
+            """{"errors":{"errorCode":403,"errorMessage":"CLIENT_IP_NOT_ALLOWED"}}"""));
+        var sut = new RakutenBooksApiClient(
+            client,
+            rateLimiter,
+            logger,
+            new RakutenAuthCredentials("test-id", "test-key", "test-affiliate"));
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.SearchComicsAsync(1, null, null));
+
+        Assert.Contains(sink, entry => entry.Contains("CLIENT_IP_NOT_ALLOWED", StringComparison.Ordinal));
+    }
+
     private static SlidingWindowRateLimiter CreateRateLimiter()
         => new(new SlidingWindowRateLimiterOptions
         {

--- a/src/tests/backend/ComiCal.Batch.Tests/Activities/RakutenBooksApiClientTests.cs
+++ b/src/tests/backend/ComiCal.Batch.Tests/Activities/RakutenBooksApiClientTests.cs
@@ -1,4 +1,5 @@
 using ComiCal.Infrastructure.Rakuten;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Net;
 using System.Threading.RateLimiting;
@@ -33,14 +34,128 @@ public sealed class RakutenBooksApiClientTests
         Assert.Equal(HttpStatusCode.ServiceUnavailable, exception.StatusCode);
     }
 
-    private sealed class StaticResponseHandler(HttpStatusCode statusCode, string body) : HttpMessageHandler
+    [Fact]
+    public async Task SearchComicsAsync_WhenRakutenReturns403_ThrowsWithForbiddenStatus()
+    {
+        using var rateLimiter = CreateRateLimiter();
+        using var client = new HttpClient(new StaticResponseHandler(
+            HttpStatusCode.Forbidden,
+            """{"error":"wrong_parameter","error_description":"applicationId is invalid"}"""));
+        var sut = new RakutenBooksApiClient(
+            client,
+            rateLimiter,
+            NullLogger<RakutenBooksApiClient>.Instance,
+            new RakutenAuthCredentials("test-id", "test-key", "test-affiliate"));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.SearchComicsAsync(1, null, null));
+
+        Assert.Equal(HttpStatusCode.Forbidden, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task SearchComicsAsync_WhenRakutenReturnsNestedError_ExtractsDiagnostic()
+    {
+        // Rakuten sometimes wraps the error inside a Body envelope.
+        using var rateLimiter = CreateRateLimiter();
+        var (logger, sink) = CreateCapturingLogger();
+        using var client = new HttpClient(new StaticResponseHandler(
+            HttpStatusCode.Forbidden,
+            """{"Header":{"Status":403},"Body":{"error":"forbidden","error_description":"application quota exceeded"}}"""));
+        var sut = new RakutenBooksApiClient(
+            client,
+            rateLimiter,
+            logger,
+            new RakutenAuthCredentials("test-id", "test-key", "test-affiliate"));
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.SearchComicsAsync(1, null, null));
+
+        Assert.Contains(sink, entry => entry.Contains("application quota exceeded", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SearchComicsAsync_WhenNoRecognizedField_IncludesBodyPrefixInDiagnostic()
+    {
+        using var rateLimiter = CreateRateLimiter();
+        var (logger, sink) = CreateCapturingLogger();
+        using var client = new HttpClient(new StaticResponseHandler(
+            HttpStatusCode.Forbidden,
+            """{"foo":"bar","baz":42}"""));
+        var sut = new RakutenBooksApiClient(
+            client,
+            rateLimiter,
+            logger,
+            new RakutenAuthCredentials("test-id", "test-key", "test-affiliate"));
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.SearchComicsAsync(1, null, null));
+
+        // Fallback must include a raw body snapshot so operators can see the payload.
+        Assert.Contains(sink, entry => entry.Contains("bodyPrefix=", StringComparison.Ordinal)
+            && entry.Contains("\"foo\":\"bar\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SearchComicsAsync_WhenNonJsonBody_IncludesBodyPrefixInDiagnostic()
+    {
+        using var rateLimiter = CreateRateLimiter();
+        var (logger, sink) = CreateCapturingLogger();
+        using var client = new HttpClient(new StaticResponseHandler(
+            HttpStatusCode.Forbidden,
+            "<html><body>Access denied by upstream firewall</body></html>",
+            mediaType: "text/html"));
+        var sut = new RakutenBooksApiClient(
+            client,
+            rateLimiter,
+            logger,
+            new RakutenAuthCredentials("test-id", "test-key", "test-affiliate"));
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.SearchComicsAsync(1, null, null));
+
+        Assert.Contains(sink, entry => entry.Contains("Access denied by upstream firewall", StringComparison.Ordinal));
+    }
+
+    private static SlidingWindowRateLimiter CreateRateLimiter()
+        => new(new SlidingWindowRateLimiterOptions
+        {
+            PermitLimit = 1,
+            Window = TimeSpan.FromSeconds(1),
+            SegmentsPerWindow = 1,
+        });
+
+    private static (ILogger<RakutenBooksApiClient> logger, List<string> sink) CreateCapturingLogger()
+    {
+        var sink = new List<string>();
+        var factory = LoggerFactory.Create(builder => builder.AddProvider(new ListLoggerProvider(sink)));
+        return (factory.CreateLogger<RakutenBooksApiClient>(), sink);
+    }
+
+    private sealed class StaticResponseHandler(HttpStatusCode statusCode, string body, string mediaType = "application/json") : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
             => Task.FromResult(new HttpResponseMessage(statusCode)
             {
-                Content = new StringContent(body),
+                Content = new StringContent(body, System.Text.Encoding.UTF8, mediaType),
             });
+    }
+
+    private sealed class ListLoggerProvider(List<string> sink) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new ListLogger(sink);
+        public void Dispose() { }
+
+        private sealed class ListLogger(List<string> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                lock (sink) { sink.Add(formatter(state, exception)); }
+            }
+        }
     }
 }


### PR DESCRIPTION
## 概要
本番で `DailyFetchOrchestrator` が **08/15 以降 7 日連続で毎日 03:00 JST に 100% 失敗**していることを App Insights で確認 (42+21+14 件の HttpRequestException が同時刻に集中発生)。原因は Rakuten Books API が 403 を返しているが、既存の診断コードが Rakuten のエラー本文を潰しているため真因が特定できない状態。

## AZ での調査結果
| 期間 | 発生元 | エラー | 件数 |
|---|---|---|--:|
| 08/15〜08/21 | `cmcl-prod-jpe-func-batch` / FetchPageActivity | `HttpRequestException: Rakuten Books API returned 403 (Forbidden)` | 42 |
| 08/15〜08/21 | 同上 / FetchOrchestrator | `Task 'FetchPageActivity' failed` | 14 |
| 08/15〜08/21 | 同上 / DailyFetchOrchestrator | `Task 'FetchOrchestrator' failed` | 14 |

Warn ログの `diagnostic` フィールド:
> `Rakuten Books API rejected a request: status=403, retryAfter=none, diagnostic=JSON response without a recognized diagnostic field.`

Rakuten の本当のエラー本文が捨てられているため、`applicationId` の revoke / quota 超過 / IP ブロック / エンベロープ形式変更 のいずれが原因か判別不能。

## 変更内容
`RakutenBooksApiClient.GetSafeErrorDiagnosticAsync` の診断抽出を強化:
1. **ネストされたラッパオブジェクトを再帰探索** (最大 depth 3)。Rakuten が `{"Header":{...},"Body":{"error_description":"..."}}` のような二段包みで返すケースをカバー
2. 認識フィールドが見つからない場合 **生 body の先頭 256 文字を diagnostic に含める** `bodyPrefix=...` として。これで次回失敗時に Rakuten の実応答本文が Application Insights に出る
3. 非 JSON (HTML ブロックページ等) も同様に本文プレフィックスと Content-Type を出す

**セキュリティ注意**: applicationId 等の認証情報は outbound URL の querystring にのみ存在し、応答 body には含まれないため、本文ダンプによる漏洩リスクなし。

## テスト
`ComiCal.Batch.Tests` に 4 件追加、既存 1 件と合わせ **5/5 成功**:
- 403 で `HttpRequestException.StatusCode == Forbidden` になる
- ネスト envelope から `error_description` を抽出しログに出る
- 未知の JSON shape で `bodyPrefix=` と生本文の一部が出る
- HTML 応答で本文の一部がログに出る

## 次アクション（マージ後）
1. main へマージ → CD-Prod で反映
2. 翌日 03:00 JST の DailyFetchOrchestrator 実行後、AppTraces で `LogRequestRejected` を再取得
3. Rakuten の実エラーメッセージに応じて (a) Key Vault の `rakuten-application-id` 更新 / (b) Rakuten Web サービス側でアプリ再有効化 / (c) レート下げ 等を実施