### PR TITLE
fix(observability): make prod batch-failure alert actually fire and notify

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -40,6 +40,9 @@ param enablePurgeProtection bool = true
 @description('Webhook URL for alert notifications (Slack or Teams); leave empty to disable')
 param alertWebhookUrl string = ''
 
+@description('Email address for alert notifications; leave empty to disable email receiver')
+param alertEmailAddress string = ''
+
 @description('Reserved: enable private endpoints for future VNet integration (currently no-op)')
 #disable-next-line no-unused-params
 param privateEndpointEnabled bool = false
@@ -60,6 +63,7 @@ module observability 'modules/observability.bicep' = {
     location: location
     logRetentionDays: logRetentionDays
     alertWebhookUrl: alertWebhookUrl
+    alertEmailAddress: alertEmailAddress
   }
 }
 

--- a/infra/modules/observability.bicep
+++ b/infra/modules/observability.bicep
@@ -13,6 +13,9 @@ param logRetentionDays int
 @description('Webhook URL for alert notifications (Slack or Teams); leave empty to disable')
 param alertWebhookUrl string = ''
 
+@description('Email address for alert notifications; leave empty to disable email receiver')
+param alertEmailAddress string = ''
+
 var logName = '${prefix}-${env}-jpe-log'
 var appiName = '${prefix}-${env}-jpe-appi'
 var actionGroupName = '${prefix}-${env}-jpe-ag'
@@ -46,6 +49,13 @@ resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
   properties: {
     groupShortName: 'cmcl'
     enabled: true
+    emailReceivers: !empty(alertEmailAddress) ? [
+      {
+        name: 'primary-email'
+        emailAddress: alertEmailAddress
+        useCommonAlertSchema: true
+      }
+    ] : []
     webhookReceivers: !empty(alertWebhookUrl) ? [
       {
         name: 'primary'
@@ -56,15 +66,22 @@ resource actionGroup 'Microsoft.Insights/actionGroups@2023-01-01' = {
   }
 }
 
-// Alert fires when the batch.failedItem custom metric total >= 5 within a 15-minute window.
-// The metric is emitted by the Batch Function App via Application Insights custom metrics.
-// Cost optimization: log alert rules are billed per rule per month, so deploy in prod only.
+// Fires when the Batch Function App has any failed function invocation in the
+// last 15 minutes. This catches the actual failure surface (uncaught exceptions
+// from FetchPageActivity / FetchOrchestrator / DailyFetchOrchestrator, etc.),
+// which the previous "batch.failedItem" customMetrics query missed entirely
+// because no code path emits that metric name — a prod outage on 2026-08-15
+// through 2026-08-22 went silent as a result.
+//
+// Cost optimization: log alert rules are billed per rule per month, so deploy
+// in prod only. AppRequests is a first-class table populated by the Functions
+// host, so this query survives even if the app never emits any custom metric.
 resource alertRule 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (env == 'prod') {
   name: alertRuleName
   location: location
   properties: {
-    displayName: 'Batch Failed Items'
-    description: 'Fires when batch.failedItem custom metric total reaches 5 or more in a 15-minute window'
+    displayName: 'Batch Function Failures'
+    description: 'Fires when the Batch Function App records at least one failed invocation within a 15-minute window.'
     severity: 2
     enabled: true
     evaluationFrequency: 'PT5M'
@@ -75,11 +92,11 @@ resource alertRule 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (env
     criteria: {
       allOf: [
         {
-          query: 'customMetrics | where name == "batch.failedItem" | summarize AggregatedValue = sum(value) by bin(timestamp, 15m)'
+          query: 'AppRequests | where AppRoleName == "${prefix}-${env}-jpe-func-batch" and Success == false | summarize AggregatedValue = count() by bin(TimeGenerated, 15m)'
           timeAggregation: 'Total'
           metricMeasureColumn: 'AggregatedValue'
           operator: 'GreaterThanOrEqual'
-          threshold: 5
+          threshold: 1
           failingPeriods: {
             numberOfEvaluationPeriods: 1
             minFailingPeriodsToAlert: 1
@@ -92,7 +109,9 @@ resource alertRule 'Microsoft.Insights/scheduledQueryRules@2022-06-15' = if (env
         actionGroup.id
       ]
     }
-    autoMitigate: false
+    // Auto-resolve once the batch recovers so the next failure raises a fresh
+    // alert instead of appending to a stale one.
+    autoMitigate: true
   }
 }
 

--- a/infra/params/dev.bicepparam
+++ b/infra/params/dev.bicepparam
@@ -8,6 +8,7 @@ param sqlVCores = 1
 param logRetentionDays = 30
 param enablePurgeProtection = false
 param alertWebhookUrl = ''
+param alertEmailAddress = readEnvironmentVariable('ALERT_EMAIL_ADDRESS', '')
 param sqlAdminPassword = readEnvironmentVariable('SQL_ADMIN_PASSWORD')
 param rakutenApplicationId = readEnvironmentVariable('RAKUTEN_APPLICATION_ID')
 param rakutenAccessKey = readEnvironmentVariable('RAKUTEN_ACCESS_KEY')

--- a/infra/params/prod.bicepparam
+++ b/infra/params/prod.bicepparam
@@ -9,6 +9,7 @@ param sqlVCores = 2
 param logRetentionDays = 90
 param enablePurgeProtection = true
 param alertWebhookUrl = ''
+param alertEmailAddress = readEnvironmentVariable('ALERT_EMAIL_ADDRESS', '')
 param sqlAdminPassword = readEnvironmentVariable('SQL_ADMIN_PASSWORD')
 param rakutenApplicationId = readEnvironmentVariable('RAKUTEN_APPLICATION_ID')
 param rakutenAccessKey = readEnvironmentVariable('RAKUTEN_ACCESS_KEY')


### PR DESCRIPTION
## 概要
先日の Rakuten 403 障害 (08/14〜08/21 の 8 日連続で毎日 03:00 JST に Batch 全滅) の際、`cmcl-prod-jpe-alert-batch-failed` は**一度も発火しなかった**。原因を AZ で調査したところ 2 つの独立した設定ミスが判明したため両方修正する。

## AZ での確認結果
| 項目 | 値 |
|---|---|
| Alert 発火履歴 (14d) | `0 件` |
| `customMetrics` に `batch.failedItem` レコード | `0 件` (該当メトリクスを emit するコード無し) |
| ActionGroup `emailReceivers` | `[]` |
| ActionGroup `webhookReceivers` | `[]` (`alertWebhookUrl=''` のため) |
| ActionGroup `smsReceivers` | `[]` |

つまり **クエリが空を返し続けるアラート** に **受信者ゼロのアクショングループ** が紐付いており、通知経路として完全に機能していなかった。

## 変更内容
### 1. アラートクエリを実データで動くものへ書き換え
Functions ホストが自動投入する `AppRequests` テーブルに対して:

```kql
AppRequests
| where AppRoleName == "cmcl-prod-jpe-func-batch" and Success == false
| summarize AggregatedValue = count() by bin(TimeGenerated, 15m)
```

閾値は `>= 1`。dry-run 検証で 08/14〜08/21 の 8 バケット全てで発火することを本番 workspace で確認済み (各バケット failedRequests=5)。

### 2. アクショングループに email receiver を追加
- `alertEmailAddress` パラメータを `observability.bicep` / `main.bicep` / dev+prod `.bicepparam` に追加
- 空文字なら receiver を作らない (現行 `alertWebhookUrl` と同じ挙動)
- 値があれば common alert schema で email receiver を 1 つ作成

CD 側で `ALERT_EMAIL_ADDRESS` シークレット/変数を設定するとメール通知が届くようになります。

### 3. `autoMitigate: true`
復旧時にアラートが自動クローズされるようにし、次の障害で新規インシデントを raise できるようにする。

## デプロイ後アクション
1. GitHub Actions の CD-Prod で `ALERT_EMAIL_ADDRESS` シークレットを設定 (例: `ops@example.com`)
2. マージ後、次回失敗発生時にアラートがメールに届くことを確認
3. 手動発火テストなら `az monitor scheduled-query update -g cmcl-prod-jpe-rg -n cmcl-prod-jpe-alert-batch-failed --threshold 0` で強制トリガも可

## Bicep 検証
- `az bicep build infra/main.bicep` 成功（既存 warning のみ）
- 本番 Log Analytics で新クエリを dry-run し過去 8 日全ての障害を検知できることを確認