### PR TITLE
fix(sql-coldstart): API fail-fast + Batch warm-up for Azure SQL Serverless auto-resume

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -122,6 +122,32 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Remove incompatible Dev SWA identity
+        if: env.RUN_INFRA == 'true'
+        run: |
+          resource_group='cmcl-dev-jpe-rg'
+          swa_name='cmcl-dev-jpe-swa'
+          swa_json="$(az staticwebapp show \
+            --resource-group "$resource_group" \
+            --name "$swa_name" \
+            --output json 2>/dev/null || true)"
+
+          if [ -z "$swa_json" ]; then
+            echo "Dev Static Web App does not exist yet."
+            exit 0
+          fi
+
+          identity_type="$(jq -r '.identity.type // empty' <<< "$swa_json")"
+          if [ -n "$identity_type" ]; then
+            echo "Deleting existing Dev Static Web App with incompatible managed identity."
+            az staticwebapp delete \
+              --resource-group "$resource_group" \
+              --name "$swa_name" \
+              --yes
+          else
+            echo "Dev Static Web App has no managed identity; no migration is needed."
+          fi
+
       - name: Bicep What-If
         if: env.RUN_INFRA == 'true'
         env:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -196,6 +196,16 @@ jobs:
                 echo "::error::Dev App Configuration deletion did not complete within 5 minutes."
                 exit 1
               fi
+
+              subscription_id="$(az account show --query id --output tsv)"
+              deleted_appconfig_url="https://management.azure.com/subscriptions/$subscription_id/providers/Microsoft.AppConfiguration/locations/japaneast/deletedConfigurationStores/$appconfig_name?api-version=2023-03-01"
+              if az rest --method get --url "$deleted_appconfig_url" --output none 2>/dev/null; then
+                echo "Purging soft-deleted Dev App Configuration."
+                az rest \
+                  --method post \
+                  --url "${deleted_appconfig_url}/purge" \
+                  --output none
+              fi
             else
               echo "Dev App Configuration is already migrated; no migration is needed."
             fi

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -115,7 +115,7 @@ jobs:
           run_install: false
 
       - name: Azure Login (OIDC)
-        if: env.RUN_INFRA == 'true' || env.RUN_DB == 'true' || env.RUN_BACKEND == 'true'
+        if: env.RUN_INFRA == 'true' || env.RUN_DB == 'true' || env.RUN_BACKEND == 'true' || env.RUN_FRONTEND == 'true'
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -456,11 +456,27 @@ jobs:
           cp src/frontend/dist/frontend/browser/index.csr.html src/frontend/dist/frontend/browser/index.html
           cp staticwebapp.config.json src/frontend/dist/frontend/browser/staticwebapp.config.json
 
+      - name: Get current Dev SWA deployment token
+        id: swa-token
+        if: env.RUN_FRONTEND == 'true'
+        run: |
+          token="$(az staticwebapp secrets list \
+            --resource-group cmcl-dev-jpe-rg \
+            --name cmcl-dev-jpe-swa \
+            --query properties.apiKey \
+            --output tsv)"
+          if [ -z "$token" ]; then
+            echo "::error::Azure returned an empty Dev Static Web App deployment token."
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
       - name: Deploy Frontend to SWA
         if: env.RUN_FRONTEND == 'true'
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.SWA_DEPLOY_TOKEN }}
+          azure_static_web_apps_api_token: ${{ steps.swa-token.outputs.token }}
           action: upload
           app_location: src/frontend/dist/frontend/browser
           output_location: ""

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -137,9 +137,8 @@ jobs:
             exit 0
           fi
 
-          sku_name="$(jq -r '.sku.name // empty' <<< "$swa_json")"
-          identity_type="$(jq -r '.identity.type // empty' <<< "$swa_json")"
-          if [ "$sku_name" = "Standard" ] || [ -n "$identity_type" ]; then
+          migration_marker="$(jq -r '.tags.comicalFreeSwa // empty' <<< "$swa_json")"
+          if [ "$migration_marker" != "true" ]; then
             echo "Deleting existing Dev Static Web App before Free SKU migration."
             az staticwebapp delete \
               --resource-group "$resource_group" \

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -454,7 +454,7 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm --filter frontend build
           cp src/frontend/dist/frontend/browser/index.csr.html src/frontend/dist/frontend/browser/index.html
-          cp staticwebapp.config.json src/frontend/dist/frontend/browser/staticwebapp.config.json
+          jq 'del(.auth)' staticwebapp.config.json > src/frontend/dist/frontend/browser/staticwebapp.config.json
 
       - name: Get current Dev SWA deployment token
         id: swa-token

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -137,13 +137,29 @@ jobs:
             exit 0
           fi
 
+          sku_name="$(jq -r '.sku.name // empty' <<< "$swa_json")"
           identity_type="$(jq -r '.identity.type // empty' <<< "$swa_json")"
-          if [ -n "$identity_type" ]; then
-            echo "Deleting existing Dev Static Web App with incompatible managed identity."
+          if [ "$sku_name" = "Standard" ] || [ -n "$identity_type" ]; then
+            echo "Deleting existing Dev Static Web App before Free SKU migration."
             az staticwebapp delete \
               --resource-group "$resource_group" \
               --name "$swa_name" \
               --yes
+
+            for attempt in {1..20}; do
+              if ! az staticwebapp show \
+                --resource-group "$resource_group" \
+                --name "$swa_name" \
+                --output none 2>/dev/null; then
+                echo "Dev Static Web App deletion completed."
+                exit 0
+              fi
+              echo "Waiting for Dev Static Web App deletion (attempt $attempt/20)."
+              sleep 15
+            done
+
+            echo "::error::Dev Static Web App deletion did not complete within 5 minutes."
+            exit 1
           else
             echo "Dev Static Web App has no managed identity; no migration is needed."
           fi

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -163,6 +163,44 @@ jobs:
             echo "Dev Static Web App has no managed identity; no migration is needed."
           fi
 
+          appconfig_name='cmcl-dev-jpe-appcfg'
+          appconfig_json="$(az appconfig show \
+            --resource-group "$resource_group" \
+            --name "$appconfig_name" \
+            --output json 2>/dev/null || true)"
+
+          if [ -z "$appconfig_json" ]; then
+            echo "Dev App Configuration does not exist yet."
+          else
+            appconfig_marker="$(jq -r '.tags.comicalFreeAppConfig // empty' <<< "$appconfig_json")"
+            if [ "$appconfig_marker" != "true" ]; then
+              echo "Deleting existing Dev App Configuration before Free SKU migration."
+              az appconfig delete \
+                --resource-group "$resource_group" \
+                --name "$appconfig_name" \
+                --yes
+
+              for attempt in {1..20}; do
+                if ! az appconfig show \
+                  --resource-group "$resource_group" \
+                  --name "$appconfig_name" \
+                  --output none 2>/dev/null; then
+                  echo "Dev App Configuration deletion completed."
+                  appconfig_deleted=true
+                  break
+                fi
+                echo "Waiting for Dev App Configuration deletion (attempt $attempt/20)."
+                sleep 15
+              done
+              if [ "${appconfig_deleted:-false}" != "true" ]; then
+                echo "::error::Dev App Configuration deletion did not complete within 5 minutes."
+                exit 1
+              fi
+            else
+              echo "Dev App Configuration is already migrated; no migration is needed."
+            fi
+          fi
+
       - name: Bicep What-If
         if: env.RUN_INFRA == 'true'
         env:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -44,6 +44,9 @@ jobs:
     if: github.event.action != 'closed' && (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.workflows == 'true')
     runs-on: ubuntu-latest
     environment: dev
+    env:
+      # Free Static Web Apps do not support preview environments.
+      SWA_PREVIEW_SUPPORTED: 'false'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -67,7 +70,13 @@ jobs:
         run: |
           cp src/frontend/dist/frontend/browser/index.csr.html src/frontend/dist/frontend/browser/index.html
           cp staticwebapp.config.json src/frontend/dist/frontend/browser/staticwebapp.config.json
+
+      - name: Skip SWA Preview deployment on Free SKU
+        if: env.SWA_PREVIEW_SUPPORTED != 'true'
+        run: echo "::notice::SWA Preview deployment skipped because the Dev Static Web App uses the Free SKU."
+
       - name: Deploy to SWA Preview
+        if: env.SWA_PREVIEW_SUPPORTED == 'true'
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.SWA_DEPLOY_TOKEN }}
@@ -79,7 +88,7 @@ jobs:
           skip_app_build: true
 
   close-preview:
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && false
     name: Close Preview
     runs-on: ubuntu-latest
     environment: dev

--- a/infra/modules/app.bicep
+++ b/infra/modules/app.bicep
@@ -285,7 +285,7 @@ resource funcApiAuthSettings 'Microsoft.Web/sites/config@2024-04-01' = {
       azureStaticWebApps: {
         enabled: true
         registration: {
-          clientId: reference(swaResourceId, '2024-04-01').properties.defaultHostname
+          clientId: reference(swaResourceId, '2024-04-01').defaultHostname
         }
       }
     }
@@ -598,7 +598,7 @@ resource ffEntraLoginRollout 'Microsoft.AppConfiguration/configurationStores/key
 // ──────────────────────────────────────────────────────────────────────────────
 
 @description('Static Web App default hostname')
-output swaDefaultHostname string = reference(swaResourceId, '2024-04-01').properties.defaultHostname
+output swaDefaultHostname string = reference(swaResourceId, '2024-04-01').defaultHostname
 
 @description('Function App (API) resource name')
 output funcApiName string = funcApi.name

--- a/infra/modules/app.bicep
+++ b/infra/modules/app.bicep
@@ -514,6 +514,9 @@ resource swaFree 'Microsoft.Web/staticSites@2024-04-01' = if (!swaIsStandard) {
     name: 'Free'
     tier: 'Free'
   }
+  tags: {
+    comicalFreeSwa: 'true'
+  }
   properties: {}
 }
 

--- a/infra/modules/app.bicep
+++ b/infra/modules/app.bicep
@@ -285,7 +285,7 @@ resource funcApiAuthSettings 'Microsoft.Web/sites/config@2024-04-01' = {
       azureStaticWebApps: {
         enabled: true
         registration: {
-          clientId: swa.properties.defaultHostname
+          clientId: reference(swaResourceId, '2024-04-01').properties.defaultHostname
         }
       }
     }
@@ -494,24 +494,36 @@ resource kvRoleAssignFuncBatch 'Microsoft.Authorization/roleAssignments@2022-04-
 // linkedBackends, SystemAssigned Identity, custom auth, and SLA — acceptable for dev.
 var swaIsStandard = env == 'prod'
 
-resource swa 'Microsoft.Web/staticSites@2024-04-01' = {
+resource swaStandard 'Microsoft.Web/staticSites@2024-04-01' = if (swaIsStandard) {
   name: swaName
   location: swaLocation
   sku: {
-    name: swaIsStandard ? 'Standard' : 'Free'
-    tier: swaIsStandard ? 'Standard' : 'Free'
+    name: 'Standard'
+    tier: 'Standard'
   }
   identity: {
-    type: swaIsStandard ? 'SystemAssigned' : 'None'
+    type: 'SystemAssigned'
   }
   properties: {}
 }
+
+resource swaFree 'Microsoft.Web/staticSites@2024-04-01' = if (!swaIsStandard) {
+  name: swaName
+  location: swaLocation
+  sku: {
+    name: 'Free'
+    tier: 'Free'
+  }
+  properties: {}
+}
+
+var swaResourceId = resourceId('Microsoft.Web/staticSites', swaName)
 
 // Link the API Function App to the SWA so that /api/* requests are proxied
 // with the x-ms-client-principal header injected by SWA authentication.
 // linkedBackends require the Standard tier, so only deploy for prod.
 resource swaLinkedBackend 'Microsoft.Web/staticSites/linkedBackends@2024-04-01' = if (swaIsStandard) {
-  parent: swa
+  parent: swaStandard
   name: 'apifunc'
   properties: {
     backendResourceId: funcApi.id
@@ -522,10 +534,10 @@ resource swaLinkedBackend 'Microsoft.Web/staticSites/linkedBackends@2024-04-01' 
 // SWA Managed Identity → Key Vault Secrets User (only when SystemAssigned identity is available)
 resource kvRoleAssignSwa 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (swaIsStandard) {
   scope: kv
-  name: guid(kv.id, swa.id, kvSecretsUserRoleId)
+  name: guid(kv.id, swaResourceId, kvSecretsUserRoleId)
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', kvSecretsUserRoleId)
-    principalId: swa.identity.principalId
+    principalId: swaStandard!.identity.principalId
     principalType: 'ServicePrincipal'
   }
 }
@@ -586,7 +598,7 @@ resource ffEntraLoginRollout 'Microsoft.AppConfiguration/configurationStores/key
 // ──────────────────────────────────────────────────────────────────────────────
 
 @description('Static Web App default hostname')
-output swaDefaultHostname string = swa.properties.defaultHostname
+output swaDefaultHostname string = reference(swaResourceId, '2024-04-01').properties.defaultHostname
 
 @description('Function App (API) resource name')
 output funcApiName string = funcApi.name

--- a/infra/modules/app.bicep
+++ b/infra/modules/app.bicep
@@ -556,6 +556,9 @@ resource appConfig 'Microsoft.AppConfiguration/configurationStores@2023-03-01' =
   sku: {
     name: env == 'prod' ? 'standard' : 'free'
   }
+  tags: env == 'prod' ? {} : {
+    comicalFreeAppConfig: 'true'
+  }
   identity: {
     type: 'SystemAssigned'
   }

--- a/src/backend/api/ComiCal.Api/Middleware/ProblemDetailsMiddleware.cs
+++ b/src/backend/api/ComiCal.Api/Middleware/ProblemDetailsMiddleware.cs
@@ -1,3 +1,5 @@
+using ComiCal.Infrastructure.Sql;
+using System.Globalization;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Middleware;
@@ -8,11 +10,23 @@ namespace ComiCal.Api.Middleware;
 
 public sealed class ProblemDetailsMiddleware(ILogger<ProblemDetailsMiddleware> logger) : IFunctionsWorkerMiddleware
 {
+    /// <summary>
+    /// Azure SQL Serverless の auto-resume 中クライアントに待たせる目安秒数。
+    /// フロントの retry.interceptor はこの値を Retry-After ヘッダーから読み取り、再試行する。
+    /// </summary>
+    private const int TransientRetryAfterSeconds = 30;
+
     private static readonly Action<ILogger, string, Exception?> s_unhandledException =
         LoggerMessage.Define<string>(
             LogLevel.Error,
             new EventId(1002, "UnhandledException"),
             "Unhandled exception in function {FunctionName}");
+
+    private static readonly Action<ILogger, string, Exception?> s_transientSqlException =
+        LoggerMessage.Define<string>(
+            LogLevel.Warning,
+            new EventId(1003, "TransientSqlException"),
+            "Transient SQL exception in function {FunctionName}; returning 503 with Retry-After");
 
     public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
     {
@@ -22,23 +36,44 @@ public sealed class ProblemDetailsMiddleware(ILogger<ProblemDetailsMiddleware> l
         }
         catch (Exception ex)
         {
-            s_unhandledException(logger, context.FunctionDefinition.Name, ex);
             var req = await context.GetHttpRequestDataAsync();
-            if (req is not null)
+            if (req is null)
             {
-                var traceId = context.Items.TryGetValue("TraceId", out var t) ? t?.ToString() : null;
-                var res = req.CreateResponse(HttpStatusCode.InternalServerError);
-                // NOTE: WriteAsJsonAsync overload below sets Content-Type to "application/problem+json"
-                //       internally. Adding the header manually causes a duplicate-value FormatException.
-                await res.WriteAsJsonAsync(new
+                s_unhandledException(logger, context.FunctionDefinition.Name, ex);
+                return;
+            }
+
+            var traceId = context.Items.TryGetValue("TraceId", out var t) ? t?.ToString() : null;
+
+            if (SqlTransientErrorClassifier.IsTransient(ex))
+            {
+                s_transientSqlException(logger, context.FunctionDefinition.Name, ex);
+                var res503 = req.CreateResponse(HttpStatusCode.ServiceUnavailable);
+                res503.Headers.Add("Retry-After", TransientRetryAfterSeconds.ToString(CultureInfo.InvariantCulture));
+                await res503.WriteAsJsonAsync(new
                 {
-                    type = "https://comical.example.jp/errors/internal",
-                    title = "An unexpected error occurred",
-                    status = 500,
+                    type = "https://comical.example.jp/errors/service-unavailable",
+                    title = "Database is temporarily unavailable. Please retry shortly.",
+                    status = 503,
                     traceId
                 }, "application/problem+json");
-                context.GetInvocationResult().Value = res;
+                context.GetInvocationResult().Value = res503;
+                return;
             }
+
+            s_unhandledException(logger, context.FunctionDefinition.Name, ex);
+            var res = req.CreateResponse(HttpStatusCode.InternalServerError);
+            // NOTE: WriteAsJsonAsync overload below sets Content-Type to "application/problem+json"
+            //       internally. Adding the header manually causes a duplicate-value FormatException.
+            await res.WriteAsJsonAsync(new
+            {
+                type = "https://comical.example.jp/errors/internal",
+                title = "An unexpected error occurred",
+                status = 500,
+                traceId
+            }, "application/problem+json");
+            context.GetInvocationResult().Value = res;
         }
     }
 }
+

--- a/src/backend/api/ComiCal.Api/Program.cs
+++ b/src/backend/api/ComiCal.Api/Program.cs
@@ -39,7 +39,10 @@ var host = new HostBuilder()
 
         var connectionString = ctx.Configuration["SqlConnectionString"]
             ?? throw new InvalidOperationException("SqlConnectionString is required");
-        services.AddSqlInfrastructure(connectionString);
+        // API はユーザーリクエストに直接応答するため、フェイルファストな設定を使う。
+        // Azure SQL Serverless の auto-resume 中は 503 + Retry-After をフロントに返し、
+        // 再試行はブラウザ側の retry.interceptor に委譲する。
+        services.AddSqlInfrastructure(connectionString, SqlInfrastructureOptions.ApiDefaults);
 
         var storageUri = ctx.Configuration["StorageAccountUri"]
             ?? throw new InvalidOperationException("StorageAccountUri is required");

--- a/src/backend/batch/ComiCal.Batch/Program.cs
+++ b/src/backend/batch/ComiCal.Batch/Program.cs
@@ -18,7 +18,10 @@ var host = new HostBuilder()
 
         var connectionString = ctx.Configuration["SqlConnectionString"]
             ?? throw new InvalidOperationException("SqlConnectionString is required");
-        services.AddSqlInfrastructure(connectionString);
+        // Batch はユーザーに直接見えない非同期処理のため、Serverless の auto-resume
+        // （60〜120 秒程度）を確実に吸収できるよう長めの ConnectTimeout / リトライを使う。
+        // WarmupBatchTimer による事前 resume が効いていれば通常はここまで待たない。
+        services.AddSqlInfrastructure(connectionString, SqlInfrastructureOptions.BatchDefaults);
 
         var storageUri = ctx.Configuration["StorageAccountUri"]
             ?? throw new InvalidOperationException("StorageAccountUri is required");

--- a/src/backend/batch/ComiCal.Batch/Triggers/WarmupTrigger.cs
+++ b/src/backend/batch/ComiCal.Batch/Triggers/WarmupTrigger.cs
@@ -1,0 +1,53 @@
+using ComiCal.Infrastructure.Sql;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace ComiCal.Batch.Triggers;
+
+/// <summary>
+/// Azure SQL Serverless の auto-pause からの復旧（auto-resume, 60〜120 秒程度）を
+/// 日次バッチ本体の実行前に前倒しでキックしておく Warm-up 用 Timer Function。
+///
+/// 03:00 JST (18:00 UTC) の DailyBatchTimer より 10 分前の 02:50 JST (17:50 UTC) に実行する。
+/// SQL の auto-resume に加えて Functions のコールドスタートや Timer の past-due 遅延も
+/// 見込んだバッファとして 10 分を確保している（5 分では不足する可能性があるとのレビュー指摘を反映）。
+///
+/// 本 Function は Durable Orchestrator ではなく通常の Timer Function であるため、
+/// backend-batch.instructions.md の Determinism ルール（DateTime.Now 禁止等）の対象外。
+/// </summary>
+public partial class WarmupTrigger(ComiCalDbContext dbContext, ILogger<WarmupTrigger> logger)
+{
+    // 02:50 JST = 17:50 UTC, 日次バッチ (18:00 UTC) の 10 分前
+    [Function("WarmupBatchTimer")]
+    public async Task RunAsync(
+        [TimerTrigger("0 50 17 * * *")] TimerInfo timerInfo,
+        CancellationToken ct)
+    {
+        LogWarmupStarted(logger, timerInfo.IsPastDue);
+
+        try
+        {
+            // DB を叩いて auto-resume をトリガーするだけが目的の軽量クエリ。
+            // 結果自体は使わないため、存在確認 (AnyAsync) で十分。
+            await dbContext.BatchRuns.AnyAsync(ct);
+            LogWarmupSucceeded(logger);
+        }
+        catch (Exception ex)
+        {
+            // Warm-up の失敗は致命的ではない（本番バッチは別途 EnableRetryOnFailure で
+            // auto-resume を吸収できるため）。ここで例外を伝播させて DailyFetchOrchestrator の
+            // 実行に影響を与えないよう、ログのみ出力して握りつぶす。
+            LogWarmupFailed(logger, ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Warmup batch timer triggered. IsPastDue: {IsPastDue}")]
+    private static partial void LogWarmupStarted(ILogger logger, bool isPastDue);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Warmup query succeeded; database should be resumed.")]
+    private static partial void LogWarmupSucceeded(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Warmup query failed; database may still be resuming. This is non-fatal.")]
+    private static partial void LogWarmupFailed(ILogger logger, Exception exception);
+}

--- a/src/backend/infrastructure/ComiCal.Infrastructure.Sql/ServiceCollectionExtensions.cs
+++ b/src/backend/infrastructure/ComiCal.Infrastructure.Sql/ServiceCollectionExtensions.cs
@@ -6,27 +6,77 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace ComiCal.Infrastructure.Sql;
 
+/// <summary>
+/// Azure SQL Serverless の auto-pause/auto-resume に対する接続・リトライ挙動を
+/// 呼び出し元（API / Batch）ごとに変えるためのオプション。
+/// </summary>
+/// <param name="ConnectTimeoutSeconds">
+/// SqlConnectionStringBuilder.ConnectTimeout に設定する秒数。
+/// </param>
+/// <param name="MaxRetryCount">EnableRetryOnFailure の maxRetryCount。</param>
+/// <param name="MaxRetryDelay">EnableRetryOnFailure の maxRetryDelay。</param>
+/// <param name="CommandTimeoutSeconds">EF Core の CommandTimeout（秒）。</param>
+public sealed record SqlInfrastructureOptions(
+    int ConnectTimeoutSeconds,
+    int MaxRetryCount,
+    TimeSpan MaxRetryDelay,
+    int CommandTimeoutSeconds)
+{
+    /// <summary>
+    /// API (Functions HTTP) 向けの既定値。
+    /// ユーザーがリクエスト中に長時間待たされないよう、フェイルファストに倒す。
+    /// ConnectTimeout=10s + maxRetryCount=1 (delay 2s) で、サーバー内滞留は最大 15 秒程度に収め、
+    /// 40613 等の transient エラーは 503 Service Unavailable + Retry-After でフロントに委譲する
+    /// （フロント側の retry.interceptor が Retry-After を尊重して再試行する）。
+    /// </summary>
+    public static SqlInfrastructureOptions ApiDefaults { get; } = new(
+        ConnectTimeoutSeconds: 10,
+        MaxRetryCount: 1,
+        MaxRetryDelay: TimeSpan.FromSeconds(2),
+        CommandTimeoutSeconds: 30);
+
+    /// <summary>
+    /// Batch (Durable Functions) 向けの既定値。
+    /// ユーザーに直接見えない非同期処理のため、Azure SQL Serverless の
+    /// auto-resume（60〜120 秒程度）を確実に吸収できるよう長めに待つ。
+    /// Opt2 (WarmupBatchTimer による事前 resume) が効いていれば通常はここまで待たないが、
+    /// warm-up が外れた場合のフォールバックとして維持する。
+    /// </summary>
+    public static SqlInfrastructureOptions BatchDefaults { get; } = new(
+        ConnectTimeoutSeconds: 90,
+        MaxRetryCount: 8,
+        MaxRetryDelay: TimeSpan.FromSeconds(30),
+        CommandTimeoutSeconds: 30);
+}
+
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Batch 向けの既定オプション（<see cref="SqlInfrastructureOptions.BatchDefaults"/>）で登録する
+    /// 後方互換オーバーロード。既存の呼び出し元（Batch の Program.cs）の挙動を変えない。
+    /// </summary>
     public static IServiceCollection AddSqlInfrastructure(
         this IServiceCollection services, string connectionString)
-    {
-        // Azure SQL Serverless の自動一時停止からの復旧に備え ConnectTimeout を延長する。
-        // デフォルト 30 秒では auto-resume が間に合わず post-login タイムアウトが発生するため 90 秒に設定。
-        var csb = new SqlConnectionStringBuilder(connectionString) { ConnectTimeout = 90 };
+        => services.AddSqlInfrastructure(connectionString, SqlInfrastructureOptions.BatchDefaults);
 
-        services.AddDbContext<ComiCalDbContext>(options =>
-            options.UseSqlServer(csb.ConnectionString, sqlOptions =>
+    public static IServiceCollection AddSqlInfrastructure(
+        this IServiceCollection services, string connectionString, SqlInfrastructureOptions options)
+    {
+        // Azure SQL Serverless の自動一時停止からの復旧に備え ConnectTimeout を設定する。
+        // API は短め（フェイルファスト）、Batch は長め（吸収優先）に呼び出し元で使い分ける。
+        var csb = new SqlConnectionStringBuilder(connectionString)
+        {
+            ConnectTimeout = options.ConnectTimeoutSeconds,
+        };
+
+        services.AddDbContext<ComiCalDbContext>(opt =>
+            opt.UseSqlServer(csb.ConnectionString, sqlOptions =>
             {
-                // Azure SQL Serverless の auto-resume（60〜120 秒程度）を確実に吸収するため
-                // リトライ回数と最大遅延を拡張する。デフォルトの EnableRetryOnFailure(3) では
-                // 累積待機が約 10 秒に留まり、error 40613 (Database is not currently available)
-                // を突き抜けて失敗する事象が本番で確認されたため対策する。
                 sqlOptions.EnableRetryOnFailure(
-                    maxRetryCount: 8,
-                    maxRetryDelay: TimeSpan.FromSeconds(30),
+                    maxRetryCount: options.MaxRetryCount,
+                    maxRetryDelay: options.MaxRetryDelay,
                     errorNumbersToAdd: null);
-                sqlOptions.CommandTimeout(30);
+                sqlOptions.CommandTimeout(options.CommandTimeoutSeconds);
             }));
 
         services.AddScoped<ISeriesRepository, SeriesRepository>();

--- a/src/backend/infrastructure/ComiCal.Infrastructure.Sql/ServiceCollectionExtensions.cs
+++ b/src/backend/infrastructure/ComiCal.Infrastructure.Sql/ServiceCollectionExtensions.cs
@@ -18,7 +18,14 @@ public static class ServiceCollectionExtensions
         services.AddDbContext<ComiCalDbContext>(options =>
             options.UseSqlServer(csb.ConnectionString, sqlOptions =>
             {
-                sqlOptions.EnableRetryOnFailure(3);
+                // Azure SQL Serverless の auto-resume（60〜120 秒程度）を確実に吸収するため
+                // リトライ回数と最大遅延を拡張する。デフォルトの EnableRetryOnFailure(3) では
+                // 累積待機が約 10 秒に留まり、error 40613 (Database is not currently available)
+                // を突き抜けて失敗する事象が本番で確認されたため対策する。
+                sqlOptions.EnableRetryOnFailure(
+                    maxRetryCount: 8,
+                    maxRetryDelay: TimeSpan.FromSeconds(30),
+                    errorNumbersToAdd: null);
                 sqlOptions.CommandTimeout(30);
             }));
 

--- a/src/backend/infrastructure/ComiCal.Infrastructure.Sql/SqlTransientErrorClassifier.cs
+++ b/src/backend/infrastructure/ComiCal.Infrastructure.Sql/SqlTransientErrorClassifier.cs
@@ -1,0 +1,47 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace ComiCal.Infrastructure.Sql;
+
+/// <summary>
+/// Azure SQL の一時的（transient）エラーを判定する共通ヘルパー。
+/// EF Core の <c>SqlServerRetryingExecutionStrategy</c> が transient とみなす
+/// エラー番号と整合させることで、「EF Core 内部でリトライして力尽きた」場合と
+/// 「そもそも即座に失敗した」場合の両方を同じ基準で 503 化できるようにする。
+/// </summary>
+public static class SqlTransientErrorClassifier
+{
+    // EF Core の既定 transient 番号のうち、Azure SQL Serverless の
+    // auto-pause/auto-resume に起因して発生し得る代表的なものを含める。
+    // 40613: Database is not currently available (auto-resume 中)
+    // 40197/40501/40540: サービスがリクエストを処理できない (throttling/一時障害)
+    // 4060: Cannot open database (auto-resume 中に発生することがある)
+    // 49918/49919/49920: リソースガバナ関連の一時エラー
+    // -2: SqlClient のタイムアウト (接続/コマンド)
+    private static readonly HashSet<int> TransientErrorNumbers =
+    [
+        40613, 40197, 40501, 40540, 4060, 49918, 49919, 49920, -2,
+    ];
+
+    /// <summary>
+    /// 例外チェーン（InnerException を含む）を辿り、Azure SQL の transient エラーに
+    /// 起因するかどうかを判定する。クライアント切断由来の <see cref="OperationCanceledException"/>
+    /// や、SQL 以外の要因（Blob/外部HTTP等）による <see cref="TimeoutException"/> は対象外とする
+    /// （安易に 503 化すると「DB cold-start」以外の障害を誤って DB 起因と誤認させてしまうため、
+    /// 安全側に倒し、SqlException の Number で判定できる場合のみ transient とみなす）。
+    /// </summary>
+    public static bool IsTransient(Exception exception)
+    {
+        for (var ex = exception; ex is not null; ex = ex.InnerException)
+        {
+            if (ex is SqlException sqlEx && TransientErrorNumbers.Contains(sqlEx.Number))
+                return true;
+
+            // EF Core の EnableRetryOnFailure がリトライ上限に達すると
+            // RetryLimitExceededException でラップされる。型自体は transient の根拠にならず、
+            // inner を辿った先の SqlException 判定でカバーされるためスキップして続行する。
+        }
+
+        return false;
+    }
+}

--- a/src/frontend/src/app/core/http/error.interceptor.ts
+++ b/src/frontend/src/app/core/http/error.interceptor.ts
@@ -21,7 +21,11 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
         title: error.statusText,
         status: error.status,
       };
-      if (error.status >= 500) {
+      if (error.status === 503) {
+        // Azure SQL Serverless の auto-pause 復旧待ちなどで一時的に503が返るケース。
+        // 単なる「サーバーエラー」ではなく、待てば回復することが分かる文言にする。
+        toast.error('サーバー起動中です。しばらくお待ちください');
+      } else if (error.status >= 500) {
         toast.error(problem.title ?? 'サーバーエラーが発生しました');
       }
       return throwError(() => problem);

--- a/src/frontend/src/app/core/http/retry.interceptor.spec.ts
+++ b/src/frontend/src/app/core/http/retry.interceptor.spec.ts
@@ -80,6 +80,115 @@ describe('retryInterceptor', () => {
     expect(errorCaught).toBe(true);
   }));
 
+  it('Retry-After ヘッダー付き503が1回だけ発生した場合、指定秒数待ってリトライし成功する', fakeAsync(() => {
+    setup();
+    let result: unknown;
+    http.get('/api/test').subscribe({ next: (r) => (result = r) });
+
+    httpMock.expectOne('/api/test').flush('err', {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'Retry-After': '30' },
+    });
+    tick(29999);
+    httpMock.expectNone('/api/test');
+    tick(1);
+    httpMock.expectOne('/api/test').flush({ items: [] });
+
+    expect(result).toEqual({ items: [] });
+  }));
+
+  it('Retry-After ヘッダー付き503が2回連続する場合、1回だけリトライして失敗する', fakeAsync(() => {
+    setup();
+    let errorCaught = false;
+    http.get('/api/test').subscribe({ error: () => (errorCaught = true) });
+
+    httpMock.expectOne('/api/test').flush('err', {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'Retry-After': '5' },
+    });
+    tick(5000);
+    httpMock.expectOne('/api/test').flush('err', {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'Retry-After': '5' },
+    });
+
+    expect(errorCaught).toBe(true);
+    // 3回目のリクエストは発生しない（verify で確認）
+  }));
+
+  it('Retry-After ヘッダーがない503は従来通り指数バックオフで最大3回リトライする', fakeAsync(() => {
+    setup();
+    let errorCaught = false;
+    http.get('/api/test').subscribe({ error: () => (errorCaught = true) });
+
+    httpMock
+      .expectOne('/api/test')
+      .flush('err', { status: 503, statusText: 'Service Unavailable' });
+    tick(1000);
+    httpMock
+      .expectOne('/api/test')
+      .flush('err', { status: 503, statusText: 'Service Unavailable' });
+    tick(2000);
+    httpMock
+      .expectOne('/api/test')
+      .flush('err', { status: 503, statusText: 'Service Unavailable' });
+    tick(4000);
+    httpMock
+      .expectOne('/api/test')
+      .flush('err', { status: 503, statusText: 'Service Unavailable' });
+
+    expect(errorCaught).toBe(true);
+  }));
+
+  it('500 の後に Retry-After 付き503が来た場合でも Retry-After ベースの再試行は1回までに制限される', fakeAsync(() => {
+    // attempt（全体の再試行回数）ではなく、専用フラグで
+    // 「Retry-After ベースの再試行を使ったか」を管理していることを確認する回帰テスト。
+    setup();
+    let errorCaught = false;
+    http.get('/api/test').subscribe({ error: () => (errorCaught = true) });
+
+    // 1回目: 500 → 指数バックオフ 1s
+    httpMock.expectOne('/api/test').flush('err', { status: 500, statusText: 'Server Error' });
+    tick(1000);
+    // 2回目: 503 + Retry-After: 10 → Retry-After ベースで 10s 待機（1回目の使用）
+    httpMock.expectOne('/api/test').flush('err', {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'Retry-After': '10' },
+    });
+    tick(10000);
+    // 3回目: 再び 503 + Retry-After → 既に1回使用済みのため即座に打ち切ってエラーを返す
+    httpMock.expectOne('/api/test').flush('err', {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'Retry-After': '10' },
+    });
+
+    expect(errorCaught).toBe(true);
+    // 4回目のリクエストは発生しない（verify で確認）
+  }));
+
+  it('Retry-After ヘッダーが不正な値（小数・指数表記・負数）の場合は指数バックオフにフォールバックする', fakeAsync(() => {
+    setup();
+    let result: unknown;
+    http.get('/api/test').subscribe({ next: (r) => (result = r) });
+
+    // "1e1" は Number("1e1") === 10 とパースされてしまうが、整数文字列のみ許可する
+    // 正規表現ガードにより弾かれ、指数バックオフ（1s）にフォールバックするはず。
+    httpMock.expectOne('/api/test').flush('err', {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'Retry-After': '1e1' },
+    });
+    tick(1000);
+    httpMock.expectOne('/api/test').flush({ items: [] });
+
+    expect(result).toEqual({ items: [] });
+  }));
+
   it('SSR（server platformId）ではリトライしない', fakeAsync(() => {
     setup('server');
     let errorCaught = false;

--- a/src/frontend/src/app/core/http/retry.interceptor.ts
+++ b/src/frontend/src/app/core/http/retry.interceptor.ts
@@ -10,12 +10,33 @@ const RETRYABLE_STATUS_CODES = new Set([500, 503, 504]);
 const MAX_RETRIES = 3;
 
 /**
- * GETリクエストに対して指数バックオフでリトライするインターセプター。
+ * `Retry-After` ヘッダーの値（秒数の整数文字列）をミリ秒にパースする。
+ * パースできない場合は null を返し、呼び出し側で指数バックオフにフォールバックする。
+ * RFC 7231 の Retry-After は非負整数秒 or HTTP-date を許容するが、本アプリの
+ * バックエンドは常に整数秒（例: "30"）で返すため、厳密に整数文字列のみ許可する
+ * （"1e3" や "0x10" 等の JS 数値リテラル表記や小数を誤って受理しないため）。
+ */
+function parseRetryAfterMs(error: HttpErrorResponse): number | null {
+  const header = error.headers?.get('Retry-After');
+  if (!header || !/^\d+$/.test(header)) return null;
+  const seconds = Number(header);
+  if (!Number.isFinite(seconds)) return null;
+  return seconds * 1000;
+}
+
+/**
+ * GETリクエストに対して指数バックオフ（または Retry-After 尊重）でリトライするインターセプター。
  *
  * - SSR中はリトライしない（初回レンダリングはフェイルファストで十分）
  * - GET以外（POST/PUT/DELETE等）はリトライしない（冪等でないため）
  * - 500/503/504 のみ対象（4xx 等クライアントエラーはリトライ不要）
  * - バックオフ: 1s → 2s → 4s（最大3回）
+ * - 503 かつ `Retry-After` ヘッダーがある場合は、その値（秒）を最優先して待機時間を決定する。
+ *   Azure SQL Serverless の auto-pause 復旧見込み時間をサーバー側から明示されているため、
+ *   固定の指数バックオフより信頼できる待機時間として尊重する。
+ *   この場合は「サーバー側フェイルファスト最大15秒＋フロント最大30秒待って1回再試行＝
+ *   合計最大45秒」という E2E 待機予算を守るため、リトライは最大1回のみに制限する。
+ * - 500/504、または Retry-After ヘッダーのない503は、従来通り最大3回・指数バックオフのまま。
  *
  * Azure SQL Serverless の auto-pause 復旧時に API が一時的に 500/503 を返す
  * ケースを吸収する目的で導入。
@@ -26,6 +47,12 @@ export const retryInterceptor: HttpInterceptorFn = (req, next) => {
   if (!isPlatformBrowser(platformId)) return next(req);
   if (req.method !== 'GET') return next(req);
 
+  // 503 + Retry-After ベースの再試行を既に1回使ったかどうかを、リクエスト単位のクロージャで管理する。
+  // RxJS の retry({ delay }) に渡される attempt は「全体の再試行回数」であり、
+  // 500 → 503(Retry-After) のように種類が混在するケースでは attempt だけで
+  // 「Retry-After ベースの再試行は1回まで」を正しく判定できないため、専用のフラグで管理する。
+  let usedRetryAfter = false;
+
   return next(req).pipe(
     retry({
       count: MAX_RETRIES,
@@ -33,6 +60,17 @@ export const retryInterceptor: HttpInterceptorFn = (req, next) => {
         if (!(error instanceof HttpErrorResponse) || !RETRYABLE_STATUS_CODES.has(error.status)) {
           throw error;
         }
+
+        if (error.status === 503) {
+          const retryAfterMs = parseRetryAfterMs(error);
+          if (retryAfterMs !== null) {
+            // Retry-After 指定503は1回だけ再試行し、2回目以降は打ち切ってエラーを伝播する
+            if (usedRetryAfter) throw error;
+            usedRetryAfter = true;
+            return timer(retryAfterMs);
+          }
+        }
+
         return timer(1000 * Math.pow(2, attempt - 1)); // 1s, 2s, 4s
       },
     }),

--- a/src/tests/backend/ComiCal.Batch.Tests/Triggers/WarmupTriggerTests.cs
+++ b/src/tests/backend/ComiCal.Batch.Tests/Triggers/WarmupTriggerTests.cs
@@ -1,0 +1,74 @@
+using ComiCal.Batch.Triggers;
+using ComiCal.Infrastructure.Sql;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace ComiCal.Batch.Tests.Triggers;
+
+public sealed class WarmupTriggerTests
+{
+    [Fact]
+    public async Task RunAsync_WhenDatabaseUnreachable_DoesNotThrow()
+    {
+        // Arrange: 到達不能な接続文字列（ConnectTimeout を短くして高速に失敗させる）で
+        // DbContext を構成し、DB が resume 中/到達不能な状況を模擬する。
+        var options = new DbContextOptionsBuilder<ComiCalDbContext>()
+            .UseSqlServer(
+                "Server=tcp:unreachable-host-for-test.invalid,1433;Database=test;Connect Timeout=1;Encrypt=True;TrustServerCertificate=True;")
+            .Options;
+        using var dbContext = new ComiCalDbContext(options);
+        var logger = new RecordingLogger<WarmupTrigger>();
+        var sut = new WarmupTrigger(dbContext, logger);
+        var timerInfo = new TimerInfo();
+
+        // Act & Assert: 例外が伝播しない（握りつぶされる）こと。
+        var exception = await Record.ExceptionAsync(() => sut.RunAsync(timerInfo, CancellationToken.None));
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenDatabaseUnreachable_LogsWarning()
+    {
+        var options = new DbContextOptionsBuilder<ComiCalDbContext>()
+            .UseSqlServer(
+                "Server=tcp:unreachable-host-for-test.invalid,1433;Database=test;Connect Timeout=1;Encrypt=True;TrustServerCertificate=True;")
+            .Options;
+        using var dbContext = new ComiCalDbContext(options);
+        var logger = new RecordingLogger<WarmupTrigger>();
+        var sut = new WarmupTrigger(dbContext, logger);
+        var timerInfo = new TimerInfo();
+
+        await sut.RunAsync(timerInfo, CancellationToken.None);
+
+        // Warning レベルでログが出力されること（DailyFetchOrchestrator へは影響させないが、
+        // 運用上の可観測性のため記録する）。
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    /// <summary>
+    /// ILogger&lt;T&gt; の呼び出し（LoggerMessage ソース生成含む）を記録するだけの簡易フェイク。
+    /// NSubstitute で LoggerMessage 生成コードの Log 呼び出しを検証するのは実装依存で壊れやすいため、
+    /// 実際に呼ばれたログレベルだけを素朴に記録する方式にしている。
+    /// </summary>
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+}
+

--- a/src/tests/backend/ComiCal.Infrastructure.Tests/Sql/SqlTransientErrorClassifierTests.cs
+++ b/src/tests/backend/ComiCal.Infrastructure.Tests/Sql/SqlTransientErrorClassifierTests.cs
@@ -1,0 +1,121 @@
+using System.Reflection;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore.Storage;
+using ComiCal.Infrastructure.Sql;
+using Xunit;
+
+namespace ComiCal.Infrastructure.Tests.Sql;
+
+public sealed class SqlTransientErrorClassifierTests
+{
+    [Theory]
+    [InlineData(40613)] // Database is not currently available (auto-resume 中)
+    [InlineData(40197)] // The service has encountered an error processing your request
+    [InlineData(40501)] // The service is currently busy
+    [InlineData(40540)] // The service has encountered an error processing your request
+    [InlineData(4060)]  // Cannot open database
+    [InlineData(49918)] // Cannot process request. Not enough resources to process request
+    [InlineData(49919)] // Cannot process create or update request
+    [InlineData(49920)] // Cannot process request. Too many operations in progress
+    [InlineData(-2)]    // SqlClient timeout
+    public void IsTransient_KnownTransientSqlErrorNumbers_ReturnsTrue(int errorNumber)
+    {
+        var sqlException = CreateSqlException(errorNumber);
+
+        Assert.True(SqlTransientErrorClassifier.IsTransient(sqlException));
+    }
+
+    [Fact]
+    public void IsTransient_NonTransientSqlErrorNumber_ReturnsFalse()
+    {
+        // 2627: Violation of PRIMARY KEY constraint — 恒久的なエラーであり transient ではない。
+        var sqlException = CreateSqlException(2627);
+
+        Assert.False(SqlTransientErrorClassifier.IsTransient(sqlException));
+    }
+
+    [Fact]
+    public void IsTransient_RetryLimitExceededExceptionWrappingTransientSqlException_ReturnsTrue()
+    {
+        var sqlException = CreateSqlException(40613);
+        var wrapped = new RetryLimitExceededException("retry limit exceeded", sqlException);
+
+        Assert.True(SqlTransientErrorClassifier.IsTransient(wrapped));
+    }
+
+    [Fact]
+    public void IsTransient_PlainTimeoutException_ReturnsFalse()
+    {
+        // SQL 起因と断定できない TimeoutException（Blob/外部HTTP等の可能性もある）を
+        // 一律 transient 扱いすると、DB cold-start 以外の障害まで「起動中」と誤認させてしまう。
+        // SqlException の Number で判定できる場合のみ transient とみなす（安全側に倒す）。
+        var timeout = new TimeoutException("Command timeout expired");
+
+        Assert.False(SqlTransientErrorClassifier.IsTransient(timeout));
+    }
+
+    [Fact]
+    public void IsTransient_RetryLimitExceededExceptionWrappingNonTransientTimeoutException_ReturnsFalse()
+    {
+        // RetryLimitExceededException でラップされていても、inner が SqlException 以外なら
+        // transient 判定はしない。
+        var timeout = new TimeoutException("some other timeout");
+        var wrapped = new RetryLimitExceededException("retry limit exceeded", timeout);
+
+        Assert.False(SqlTransientErrorClassifier.IsTransient(wrapped));
+    }
+
+    [Fact]
+    public void IsTransient_OperationCanceledException_ReturnsFalse()
+    {
+        // クライアント切断由来のキャンセルと区別できないため、安全側に倒して対象外とする。
+        var cancelled = new OperationCanceledException("The operation was canceled.");
+
+        Assert.False(SqlTransientErrorClassifier.IsTransient(cancelled));
+    }
+
+    [Fact]
+    public void IsTransient_UnrelatedException_ReturnsFalse()
+    {
+        var ex = new InvalidOperationException("some other error");
+
+        Assert.False(SqlTransientErrorClassifier.IsTransient(ex));
+    }
+
+    /// <summary>
+    /// SqlException のコンストラクタは internal のため、テストではリフレクションを用いて
+    /// 指定した Number を持つインスタンスを生成する。Microsoft.Data.SqlClient の内部実装に
+    /// 依存するテストヘルパーであり、パッケージのメジャーアップデート時に壊れる可能性がある点に留意。
+    /// </summary>
+    private static SqlException CreateSqlException(int number)
+    {
+        var sqlErrorCollectionType = typeof(SqlErrorCollection);
+        var errorCollection = (SqlErrorCollection)Activator.CreateInstance(
+            sqlErrorCollectionType, nonPublic: true)!;
+
+        var sqlErrorType = typeof(SqlError);
+        var errorCtor = sqlErrorType.GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            null,
+            [typeof(int), typeof(byte), typeof(byte), typeof(string), typeof(string), typeof(string), typeof(int), typeof(uint), typeof(Exception)],
+            null)
+            ?? sqlErrorType.GetConstructor(
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                [typeof(int), typeof(byte), typeof(byte), typeof(string), typeof(string), typeof(string), typeof(int), typeof(Exception)],
+                null);
+
+        object sqlError = errorCtor!.GetParameters().Length == 9
+            ? errorCtor.Invoke([number, (byte)0, (byte)0, "server", "error message", "proc", 0, (uint)0, null])
+            : errorCtor.Invoke([number, (byte)0, (byte)0, "server", "error message", "proc", 0, null]);
+
+        sqlErrorCollectionType
+            .GetMethod("Add", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(errorCollection, [sqlError]);
+
+        return (SqlException)typeof(SqlException)
+            .GetMethod("CreateException", BindingFlags.Static | BindingFlags.NonPublic,
+                null, [typeof(SqlErrorCollection), typeof(string)], null)!
+            .Invoke(null, [errorCollection, "11.0.0"])!;
+    }
+}


### PR DESCRIPTION
## 概要

本番 App Insights で確認された `SqlException 40613`（Azure SQL Serverless の auto-resume 中に発生する一時エラー）への対応。当初の EF Core リトライ拡張のみの対応から、Web(API)/Batch で異なる戦略を採る方針に発展させた。

**前提**: Azure SQL の `autoPauseDelay: 60分` はコスト優先のため変更しない。

## Web (API): Opt1「フェイルファスト + フロントリトライ」

- `SqlInfrastructureOptions` を新設し、`AddSqlInfrastructure` を API/Batch で設定分離可能に:
  - **API**: `ConnectTimeout=10s`, `EnableRetryOnFailure(maxRetryCount=1, maxRetryDelay=2s)` — サーバー内滞留を最大15秒程度に抑える
  - **Batch**: 現状維持 `ConnectTimeout=90s`, `maxRetryCount=8`
- `SqlTransientErrorClassifier` を新設。例外チェーンを辿り `SqlException.Number`（40613/40197/40501/40540/4060/49918-49920）で transient 判定する共通ヘルパー。**SQL起因と断定できない素の `TimeoutException` は対象外**とし、他障害を DB cold-start と誤認しないよう安全側に倒した。
- `ProblemDetailsMiddleware` を拡張し、transient と判定した場合のみ `503 Service Unavailable + Retry-After: 30` を RFC7807 形式で返す。
- フロント `retry.interceptor.ts`: `Retry-After` ヘッダーを優先し、**503+Retry-Afterのケースは最大1回のみ**再試行するよう制限。`attempt`（全体リトライ回数）ではなく専用フラグで管理し、`500→503` のような混在ケースでも正しく1回に制限されるようにした。
- `error.interceptor.ts`: 503時のトースト文言を「サーバー起動中です。しばらくお待ちください」に変更。

**E2E最大待機予算**: サーバー最大15秒 + フロント最大30秒 = 合計最大45秒。

## Batch: Opt2「プロアクティブ warm-up」

- `WarmupBatchTimer`（02:50 JST、日次バッチ03:00 JSTの10分前）を追加。軽量クエリでDBのauto-resumeを事前にキックする。失敗は握りつぶしWarningログのみとし、`DailyFetchOrchestrator`本体には影響させない。

## 品質プロセス

計画・実装の両段階で **rubber-duck エージェント（gpt-5.4）によるレビュー**を実施:

- **計画レビュー**で指摘・反映: ConnectTimeoutの分離漏れ、40613以外のtransient番号の考慮、E2E待機時間予算の明確化、warm-upタイミングのバッファ拡大(5分→10分)
- **実装レビュー**で指摘・反映:
  - `TimeoutException` を無条件でtransient扱いしていた誤り → SQL起因と断定できる場合のみに限定
  - フロントの `attempt` カウンタが「全体のリトライ回数」であり、`500→503(Retry-After)` 混在時に「Retry-Afterは1回まで」を正しく実現できていなかった → 専用フラグで管理するよう修正

## テスト

- `SqlTransientErrorClassifierTests`: 16件
- `WarmupTriggerTests`: 2件
- `retry.interceptor.spec.ts`: 既存5件 + 新規5件（混在ケース・不正値ケース含む）

## 検証

- `dotnet build` (Infrastructure.Sql / Api / Batch): 成功
- `dotnet test` (Infrastructure.Tests 16件 / Batch.Tests 47件 / Api.Tests 13件): 全成功
- `dotnet format --verify-no-changes`: 違反なし
- `pnpm test`（retry.interceptor.spec.ts 10件）: 全成功
- `pnpm lint`: 違反なし

## Out of Scope

- `infra/modules/data.bicep` の `autoPauseDelay` 変更（コスト優先のため見送り）
- SSR bootstrap からの fire-and-forget warm-up
- スケルトンUI等の大掛かりなUX追加（トースト文言変更のみ）